### PR TITLE
Support byte range requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,5 +144,26 @@ S3Adapter.prototype.getFileLocation = function(config, filename) {
   return (config.mount + '/files/' + config.applicationId + '/' + filename);
 }
 
+S3Adapter.prototype.getFileStream = async function(filename, req, res) {
+  const params = {
+    Key: this._bucketPrefix + filename,
+    Range: req.get('Range'),
+  };
+  await this.createBucket();
+  this._s3Client.getObject(params, (error, data) => {
+    if (error !== null || (data && !data.Body)) {
+      return res.sendStatus(404);
+    }
+    res.writeHead(206, {
+      'Accept-Ranges': data.AcceptRanges,
+      'Content-Length': data.ContentLength,
+      'Content-Range': data.ContentRange,
+      'Content-Type': data.ContentType,
+    });
+    res.write(data.Body);
+    res.end();
+  });
+}
+
 module.exports = S3Adapter;
 module.exports.default = S3Adapter;

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ S3Adapter.prototype.getFileLocation = function(config, filename) {
   return (config.mount + '/files/' + config.applicationId + '/' + filename);
 }
 
-S3Adapter.prototype.getFileStream = function (filename, req, res) {
+S3Adapter.prototype.handleFileStream = function (filename, req, res) {
   const params = {
     Key: this._bucketPrefix + filename,
     Range: req.get('Range'),

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -177,7 +177,7 @@ describe('S3Adapter tests', () => {
         write: jasmine.createSpy('write'),
         end: jasmine.createSpy('end'),
       };
-      s3.getFileStream('test.mov', req, resp).then((data) => {
+      s3.handleFileStream('test.mov', req, resp).then((data) => {
         expect(data.toString('utf8')).toBe('hello world');
         expect(resp.writeHead).toHaveBeenCalled();
         expect(resp.write).toHaveBeenCalled();
@@ -201,7 +201,7 @@ describe('S3Adapter tests', () => {
         write: jasmine.createSpy('write'),
         end: jasmine.createSpy('end'),
       };
-      s3.getFileStream('test.mov', req, resp).catch((error) => {
+      s3.handleFileStream('test.mov', req, resp).catch((error) => {
         expect(error).toBe('FileNotFound');
         expect(resp.writeHead).not.toHaveBeenCalled();
         expect(resp.write).not.toHaveBeenCalled();
@@ -226,7 +226,7 @@ describe('S3Adapter tests', () => {
         write: jasmine.createSpy('write'),
         end: jasmine.createSpy('end'),
       };
-      s3.getFileStream('test.mov', req, resp).catch((error) => {
+      s3.handleFileStream('test.mov', req, resp).catch((error) => {
         expect(error).toBe(data);
         expect(resp.writeHead).not.toHaveBeenCalled();
         expect(resp.write).not.toHaveBeenCalled();

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -153,6 +153,88 @@ describe('S3Adapter tests', () => {
     });
   });
 
+  describe('getFileStream', () => {
+    it('should handle range bytes', () => {
+      const s3 = new S3Adapter('accessKey', 'secretKey', 'myBucket');
+      s3._s3Client = {
+        createBucket: callback => callback(),
+        getObject: (params, callback) => {
+          const { Range } = params;
+
+          expect(Range).toBe('bytes=0-1');
+
+          const data = {
+            Body: Buffer.from('hello world', 'utf8'),
+          };
+          callback(null, data);
+        },
+      };
+      const req = {
+        get: () => 'bytes=0-1',
+      };
+      const resp = {
+        writeHead: jasmine.createSpy('writeHead'),
+        write: jasmine.createSpy('write'),
+        end: jasmine.createSpy('end'),
+      };
+      s3.getFileStream('test.mov', req, resp).then((data) => {
+        expect(data.toString('utf8')).toBe('hello world');
+        expect(resp.writeHead).toHaveBeenCalled();
+        expect(resp.write).toHaveBeenCalled();
+        expect(resp.end).toHaveBeenCalled();
+      });
+    });
+
+    it('should handle range bytes error', () => {
+      const s3 = new S3Adapter('accessKey', 'secretKey', 'myBucket');
+      s3._s3Client = {
+        createBucket: callback => callback(),
+        getObject: (params, callback) => {
+          callback('FileNotFound', null);
+        },
+      };
+      const req = {
+        get: () => 'bytes=0-1',
+      };
+      const resp = {
+        writeHead: jasmine.createSpy('writeHead'),
+        write: jasmine.createSpy('write'),
+        end: jasmine.createSpy('end'),
+      };
+      s3.getFileStream('test.mov', req, resp).catch((error) => {
+        expect(error).toBe('FileNotFound');
+        expect(resp.writeHead).not.toHaveBeenCalled();
+        expect(resp.write).not.toHaveBeenCalled();
+        expect(resp.end).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should handle range bytes no data', () => {
+      const s3 = new S3Adapter('accessKey', 'secretKey', 'myBucket');
+      const data = { Error: 'NoBody' };
+      s3._s3Client = {
+        createBucket: callback => callback(),
+        getObject: (params, callback) => {
+          callback(null, data);
+        },
+      };
+      const req = {
+        get: () => 'bytes=0-1',
+      };
+      const resp = {
+        writeHead: jasmine.createSpy('writeHead'),
+        write: jasmine.createSpy('write'),
+        end: jasmine.createSpy('end'),
+      };
+      s3.getFileStream('test.mov', req, resp).catch((error) => {
+        expect(error).toBe(data);
+        expect(resp.writeHead).not.toHaveBeenCalled();
+        expect(resp.write).not.toHaveBeenCalled();
+        expect(resp.end).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('getFileLocation', () => {
     var config = {
       mount: 'http://my.server.com/parse',


### PR DESCRIPTION
Requires changes in https://github.com/parse-community/parse-server/pull/6028

The current server does implement `handleFileStream` in the FilesRouter but most file streams would have a different implementation. In [#6028](https://github.com/parse-community/parse-server/pull/6028). I moved the implementation directly into the adapter.

To prevent breaking changes i could add on the server to check for a different function other that `getFileStream`.

Any suggestions would be appreciated.
