### PR TITLE
Correctly use endpoint in s3overrides

### DIFF
--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -64,6 +64,7 @@ const optionsFromArguments = function optionsFromArguments(args) {
       options.signatureVersion = otherOptions.signatureVersion;
       options.globalCacheControl = otherOptions.globalCacheControl;
       options.ServerSideEncryption = otherOptions.ServerSideEncryption;
+      s3overrides = otherOptions.s3overrides;
     }
   } else if (args.length === 1) {
     Object.assign(options, stringOrOptions);

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -1,3 +1,4 @@
+const AWS = require('aws-sdk');
 const config = require('config');
 const filesAdapterTests = require('parse-server-conformance-tests').files;
 const S3Adapter = require('../index.js');
@@ -131,6 +132,19 @@ describe('S3Adapter tests', () => {
       expect(s3._s3Client.config.secretAccessKey).toEqual('secret-2');
       expect(s3._s3Client.config.params.Bucket).toEqual('bucket-2');
       expect(s3._bucketPrefix).toEqual('test/');
+    });
+
+    it('should accept endpoint as an override option in args', () => {
+      const otherEndpoint = new AWS.Endpoint('nyc3.digitaloceanspaces.com');
+      const confObj = {
+        bucketPrefix: 'test/',
+        bucket: 'bucket-1',
+        secretKey: 'secret-1',
+        accessKey: 'key-1',
+        s3overrides: { endpoint: otherEndpoint },
+      };
+      const s3 = new S3Adapter(confObj);
+      expect(s3._s3Client.endpoint).toEqual(otherEndpoint);
     });
 
     it('should accept options and overrides as args', () => {

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -144,7 +144,13 @@ describe('S3Adapter tests', () => {
         s3overrides: { endpoint: otherEndpoint },
       };
       const s3 = new S3Adapter(confObj);
-      expect(s3._s3Client.endpoint).toEqual(otherEndpoint);
+      expect(s3._s3Client.endpoint.protocol).toEqual(otherEndpoint.protocol);
+      expect(s3._s3Client.endpoint.host).toEqual(otherEndpoint.host);
+      expect(s3._s3Client.endpoint.port).toEqual(otherEndpoint.port);
+      expect(s3._s3Client.endpoint.hostname).toEqual(otherEndpoint.hostname);
+      expect(s3._s3Client.endpoint.pathname).toEqual(otherEndpoint.pathname);
+      expect(s3._s3Client.endpoint.path).toEqual(otherEndpoint.path);
+      expect(s3._s3Client.endpoint.href).toEqual(otherEndpoint.href);
     });
 
     it('should accept options and overrides as args', () => {


### PR DESCRIPTION
I believe this fixes #77 . This correctly passes the endpoint override to the AWS SDK. I haven't figured out how to test this in the full parse-server yet though.