### PR TITLE
Add file ACL override parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,17 @@ This option is provided for backward compatibility and will be removed in the fo
 
 The preferred method is to use the default AWS credentials pattern.  If no AWS credentials are explicitly configured, the AWS SDK will look for credentials in the standard locations used by all AWS SDKs and the AWS CLI. More info can be found in [the docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).  For more information on AWS best practices, see [IAM Best Practices User Guide](http://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html).
 
-# usage with parse-server
+# Usage with Parse Server
 
-### using a config file
+### Parameters
+
+*(This list is still incomplete and in the works, in the meantime find more descriptions in the chapters below.)*
+
+| Parameter | Optional | Default value | Environment variable | Description |
+|-----------|----------|----------|----------|
+| fileAcl | yes | undefined | S3_FILE_ACL | Sets the [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) of the file when storing it in the S3 bucket. Setting this parameter overrides the file ACL that would otherwise depend on the `directAccess` parameter. Setting the value `none` causes any ACL parameter to be removed that would otherwise be set. |
+
+### Using a config file
 
 ```
 {
@@ -62,6 +70,7 @@ The preferred method is to use the default AWS credentials pattern.  If no AWS c
       "region": 'us-east-1', // default value
       "bucketPrefix": '', // default value
       "directAccess": false, // default value
+      "fileAcl": null, // default value
       "baseUrl": null, // default value
       "baseUrlDirect": false, // default value
       "signatureVersion": 'v4', // default value

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ class S3Adapter {
     this._bucket = options.bucket;
     this._bucketPrefix = options.bucketPrefix;
     this._directAccess = options.directAccess;
+    this._fileAcl = options.fileAcl;
     this._baseUrl = options.baseUrl;
     this._baseUrlDirect = options.baseUrlDirect;
     this._signatureVersion = options.signatureVersion;
@@ -85,8 +86,13 @@ class S3Adapter {
     if (this._generateKey instanceof Function) {
       params.Key = this._bucketPrefix + this._generateKey(filename);
     }
-
-    if (this._directAccess) {
+    if (this._fileAcl) {
+      if (this._fileAcl === 'none') {
+        delete params.ACL;
+      } else {
+        params.ACL = this._fileAcl;
+      }
+    } else if (this._directAccess) {
       params.ACL = 'public-read';
     }
     if (contentType) {

--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -59,6 +59,7 @@ const optionsFromArguments = function optionsFromArguments(args) {
     if (otherOptions) {
       options.bucketPrefix = otherOptions.bucketPrefix;
       options.directAccess = otherOptions.directAccess;
+      options.fileAcl = otherOptions.fileAcl;
       options.baseUrl = otherOptions.baseUrl;
       options.baseUrlDirect = otherOptions.baseUrlDirect;
       options.signatureVersion = otherOptions.signatureVersion;
@@ -88,6 +89,7 @@ const optionsFromArguments = function optionsFromArguments(args) {
   options = fromEnvironmentOrDefault(options, 'bucketPrefix', 'S3_BUCKET_PREFIX', '');
   options = fromEnvironmentOrDefault(options, 'region', 'S3_REGION', DEFAULT_S3_REGION);
   options = fromEnvironmentOrDefault(options, 'directAccess', 'S3_DIRECT_ACCESS', false);
+  options = fromEnvironmentOrDefault(options, 'fileAcl', 'S3_FILE_ACL', null);
   options = fromEnvironmentOrDefault(options, 'baseUrl', 'S3_BASE_URL', null);
   options = fromEnvironmentOrDefault(options, 'baseUrlDirect', 'S3_BASE_URL_DIRECT', false);
   options = fromEnvironmentOrDefault(options, 'signatureVersion', 'S3_SIGNATURE_VERSION', 'v4');


### PR DESCRIPTION
The new parameter allows the ACL of the file to be overridden when it is stored to the S3 bucket.

Bonus:
- Added a Table of Parameters (in progress) to the readme file to give more clarity about the adapter parameters.
- Added missing test cases whether the existing `directAccess` parameter correctly sets the file ACL.

Closes https://github.com/parse-community/parse-server-s3-adapter/issues/89