### PR TITLE
Don't send tags during upload if none are in options

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ class S3Adapter {
     if (options.metadata && typeof options.metadata === 'object') {
       params.Metadata = options.metadata;
     }
-    if (options.tags && typeof options.tags === 'object') {
+    if (options.tags && typeof options.tags === 'object' && Object.keys(options.tags).length > 0) {
       const serializedTags = serialize(options.tags);
       params.Tagging = serializedTags;
     }

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -521,6 +521,21 @@ describe('S3Adapter tests', () => {
       await s3.createFile(fileName, 'hello world', 'text/utf8', { tags });
     });
 
+    it('should not send tags to s3 upload function, where tags object is empty', async () => {
+      const s3 = makeS3Adapter(options);
+      s3._s3Client.upload = (params, callback) => {
+        const { Tagging } = params;
+        expect(Tagging).toBeUndefined();
+        const data = {
+          Body: Buffer.from('hello world', 'utf8'),
+        };
+        callback(null, data);
+      };
+      const fileName = 'randomFileName.txt';
+      const tags = { };
+      await s3.createFile(fileName, 'hello world', 'text/utf8', { tags });
+    });
+
     it('should save a file with proper ACL with direct access', async () => {
       // Create adapter
       options.directAccess = true;


### PR DESCRIPTION
Some S3 compatible storages don't support tags and upload fails, when tags are presented (even empty one). The example of this storage is Digital Ocean spaces, that we are using.

This small change sends tags only in case, when tags are presented in file options. It should be safe change, because it there should not have been difference between file uploaded with empty tags and no tags (IMHO). Also when somebody wants to use tags, he wants to use storage, that supports tags, so that it is fine, that upload fails (as fails now).