### PR TITLE
refactor: bump xml2js and aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/parse-community/parse-server-s3-adapter#readme",
   "dependencies": {
-    "aws-sdk": "2.907.0"
+    "aws-sdk": "2.1354.0"
   },
   "devDependencies": {
     "parse": "3.3.1",


### PR DESCRIPTION
As per https://github.com/parse-community/parse-server-s3-adapter/pull/181

Bumps xml2js to 0.5.0 and updates ancestor dependency aws-sdk. These dependencies need to be updated together.

- Updates xml2js from 0.4.19 to 0.5.0
- Updates aws-sdk from 2.907.0 to 2.1354.0