### PR TITLE
feat: Revise createFile logic to return modified filenames and location

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,10 +180,32 @@ class S3Adapter {
   }
 
   // For a given config object, filename, and data, store a file in S3
-  // Returns a promise containing the S3 object creation response
-  async createFile(filename, data, contentType, options = {}) {
+  // Returns a promise containing the S3 object creation response, extended with
+  // the name the file was stored under and, when a server config is supplied,
+  // the url it can be read from. Callers that ignore those keys are unaffected.
+  async createFile(filename, data, contentType, options = {}, config = {}) {
     const params = this._buildCreateFileParams(filename, data, contentType, options);
     const endpoint = this._endpoint || `https://${this._bucket}.s3.${this._region}.amazonaws.com`;
+    // The name the file was actually stored under, which generateKey may have
+    // changed. The bucket prefix is the adapter's own concern, so it is not
+    // part of the name the caller knows the file by.
+    const name = params.Key.startsWith(this._bucketPrefix)
+      ? params.Key.slice(this._bucketPrefix.length)
+      : params.Key;
+
+    const buildResult = async (response) => {
+      // A url is only resolvable when the caller passed a server config;
+      // getFileLocation needs mount and applicationId to build one.
+      const url =
+        config && config.mount && config.applicationId
+          ? await this.getFileLocation(config, name)
+          : undefined;
+      return Object.assign(response || {}, {
+        Location: `${endpoint}/${params.Key}`,
+        name,
+        ...(url ? { url } : {}),
+      });
+    };
 
     // Streaming upload path
     if (typeof data?.pipe === 'function') {
@@ -195,10 +217,7 @@ class S3Adapter {
         });
         this.createBucket()
           .then(() => upload.done())
-          .then(
-            (response) => resolve(Object.assign(response || {}, { Location: `${endpoint}/${params.Key}` })),
-            reject
-          );
+          .then((response) => buildResult(response).then(resolve, reject), reject);
       });
     }
 
@@ -206,7 +225,7 @@ class S3Adapter {
     await this.createBucket();
     const command = new PutObjectCommand(params);
     const response = await this._s3Client.send(command);
-    return Object.assign(response || {}, { Location: `${endpoint}/${params.Key}` });
+    return buildResult(response);
   }
 
   async deleteFile(filename) {

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -905,6 +905,96 @@ describe('S3Adapter tests', () => {
       expect(s3ClientMock.send).toHaveBeenCalledWith(jasmine.any(PutObjectCommand));
     });
 
+    describe('returned name and url', () => {
+      const testConfig = {
+        mount: 'http://my.server.com/parse',
+        applicationId: 'xxxx',
+      };
+
+      it('should return the filename it stored', async () => {
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        const result = await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+
+        // Without the bucket prefix, which is not the caller's concern.
+        expect(result.name).toBe('file.txt');
+      });
+
+      it('should return the filename generateKey produced', async () => {
+        options.generateKey = filename => `stamped_${filename}`;
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        const result = await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+
+        expect(result.name).toBe('stamped_file.txt');
+        expect(result.Location).toContain('/test/stamped_file.txt');
+      });
+
+      it('should return a url when a server config is supplied', async () => {
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        const result = await s3.createFile('file.txt', 'hello world', 'text/utf8', {}, testConfig);
+
+        expect(result.url).toBe(await s3.getFileLocation(testConfig, 'file.txt'));
+      });
+
+      it('should return a url built from the generated filename', async () => {
+        options.generateKey = filename => `stamped_${filename}`;
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        const result = await s3.createFile('file.txt', 'hello world', 'text/utf8', {}, testConfig);
+
+        expect(result.url).toContain('stamped_file.txt');
+      });
+
+      it('should omit the url when no server config is supplied', async () => {
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        const result = await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+
+        // Omitted rather than null, so a caller merging this into file
+        // metadata does not overwrite a good url.
+        expect('url' in result).toBe(false);
+      });
+
+      it('should keep returning the S3 response and Location', async () => {
+        s3ClientMock.send.and.returnValue(Promise.resolve({ ETag: '"abc123"' }));
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        const result = await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+
+        expect(result.ETag).toBe('"abc123"');
+        expect(result.Location).toBe(`https://bucket-1.s3.${s3._region}.amazonaws.com/test/file.txt`);
+      });
+
+      it('should return the name and url for a stream', async () => {
+        const rewiredModule = rewire('../index');
+        rewiredModule.__set__('Upload', function () {
+          this.done = () => Promise.resolve();
+          this.abort = () => Promise.resolve();
+        });
+        const RewiredS3Adapter = rewiredModule;
+        const s3 = new RewiredS3Adapter(options);
+        s3._s3Client = s3ClientMock;
+        s3._hasBucket = true;
+
+        const stream = new Readable();
+        stream.push('hello world');
+        stream.push(null);
+
+        const result = await s3.createFile('file.txt', stream, 'text/plain', {}, testConfig);
+
+        expect(result.name).toBe('file.txt');
+        expect(result.url).toContain('file.txt');
+      });
+    });
+
     it('should save a stream with metadata added', async () => {
       const rewiredModule = rewire('../index');
       let uploadParams;


### PR DESCRIPTION
## Issue

Closes: #237

`createFile()` reports back only the S3 response and a `Location`. It does not say what name the file was actually stored under, so when `generateKey` rewrites the key, the caller has no way to learn the new name and later builds a url for a file that is not there. It also has no access to the server config, so it cannot resolve the file's url itself.

Pairs with parse-community/parse-server#9557, which teaches `FilesController` to use `createFile`'s reported name and url. Without that PR this change is inert but harmless, since the added keys are simply ignored.

Together with that PR this also resolves #87, where a filename produced by `generateKey` never reaches Parse Server and the only workaround is turning on `preserveFileName` and moving naming to the client. Not marked as closing, because it takes both halves. The suggestion there of repurposing `validateFilename` to return a modified name is not needed once `createFile` reports the name it used.

## Approach

`createFile` now takes an optional fifth `config` argument and extends its existing return value with two keys:

- `name`, the filename as stored, after `generateKey`, without the bucket prefix, which is the adapter's own concern.
- `url`, resolved through `getFileLocation` when the caller supplied a config carrying `mount` and `applicationId`. It is **omitted** rather than set to null when it cannot be resolved, so a caller merging the result into file metadata cannot clobber a good url with a null.

Both return paths are covered, the streaming `Upload` path and the buffer `PutObjectCommand` path.

## Compatibility

The return value is extended, not replaced. `createFile` still resolves to the S3 response object carrying `Location`, so existing callers and the tests that assert `response.Location` are unaffected. An adapter consumer that ignores `name` and `url` sees no change in behavior.

This is a change from the earlier revision of this PR, which returned a bespoke `{ location, name, url }` and dropped the S3 response. That was a breaking change to the adapter's public contract for no benefit, since the same information fits alongside what is already returned.

## Scope

Deliberately left out, since each is a separate concern and this PR is already gated on parse-server#9557:

- Async `generateKey` support, result validation, and passing `contentType`/`options` to the generator. Worth doing, but it is a change to the `generateKey` contract rather than to what `createFile` reports.
- Reworking how the location base is derived for custom endpoints where the bucket appears in the host or path. That is an independent bug.
- Percent-encoding the `Location` url, which is #591.

## Tests

`spec/test.spec.js` gains a `returned name and url` block covering the stored name, the name after `generateKey`, url resolution with and without a config, url resolution from a generated name, the stream path, and a regression test asserting the S3 response and `Location` still come back unchanged.

Full suite passes.


## Related pull requests

These all touch `createFile` or `getFileLocation` in `index.js`. Merging them in this order leaves the fewest conflicts, verified by trial merges of all six together, which pass the suite once resolved:

**#336 → #594 → #597 → #591 → #593 → #242**

- #336 presigned urls used a pre-encoded key
- #594 bucket region missing from the direct access url
- #597 asynchronous `generateKey`
- #591 percent-encoding of the `Location` url
- #593 `Location` omitted the bucket for custom endpoints
- #242 `createFile` reporting the stored name and url

#336 and #594 conflict with nothing. The rest collide on the `createFile` prologue and on the same anchor in `spec/test.spec.js`, where the conflict truncates each side's block, so the incoming `describe` has to be re-inserted whole rather than resolved line by line.
