### PR TITLE
fix: Prevent double-encoded presigned urls from s3

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,10 +253,12 @@ class S3Adapter {
     }
 
     const fileKey = `${this._bucketPrefix}${fileName}`;
+    // For presigned URLs, use the original unencoded filename to prevent double encoding
+    const presignedFileKey = `${this._bucketPrefix}${filename}`;
 
     let presignedUrl = '';
     if (this._presignedUrl) {
-      const params = { Bucket: this._bucket, Key: fileKey };
+      const params = { Bucket: this._bucket, Key: presignedFileKey };
       const options = this._presignedUrlExpires ? { expiresIn: this._presignedUrlExpires } : {};
 
       const command = new GetObjectCommand(params);

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -639,20 +639,23 @@ describe('S3Adapter tests', () => {
       expect(fileLocation).toContain('X-Amz-SignedHeaders=host');
     });
 
-    it('should not double-encode special characters in presigned URLs', async () => {
-      delete options.baseUrl;
-      options.presignedUrl = true;
-      const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
+    // The SDK encodes the key itself, so a pre-encoded key comes back encoded
+    // twice: the percent sign of the first encoding is escaped to %25.
+    [
+      { characters: 'brackets', filename: 'doc[123].pdf', once: 'doc%5B123%5D.pdf', twice: 'doc%255B123%255D.pdf' },
+      { characters: 'spaces', filename: 'doc 123.pdf', once: 'doc%20123.pdf', twice: 'doc%2520123.pdf' },
+      { characters: 'ampersands', filename: 'doc&123.pdf', once: 'doc%26123.pdf', twice: 'doc%2526123.pdf' },
+    ].forEach(({ characters, filename, once, twice }) => {
+      it(`should not double-encode ${characters} in presigned URLs`, async () => {
+        delete options.baseUrl;
+        options.presignedUrl = true;
+        const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
 
-      // Test filename with special characters that need URL encoding
-      const specialFilename = 'doc[123].pdf';
-      const fileLocation = await s3.getFileLocation(testConfig, specialFilename);
+        const fileLocation = await s3.getFileLocation(testConfig, filename);
 
-      // Should be encoded once (not double-encoded)
-      // %5B and %5D are correct encoding for [ and ]
-      // Double encoding would be %255B and %255D
-      expect(fileLocation).toContain('doc%5B123%5D.pdf');
-      expect(fileLocation).not.toContain('doc%255B123%255D.pdf');
+        expect(fileLocation).toContain(once);
+        expect(fileLocation).not.toContain(twice);
+      });
     });
 
     it('should keep the path separator in presigned URLs for nested filenames', async () => {

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -638,6 +638,35 @@ describe('S3Adapter tests', () => {
       expect(fileLocation).toContain('X-Amz-Algorithm=AWS4-HMAC-SHA256');
       expect(fileLocation).toContain('X-Amz-SignedHeaders=host');
     });
+
+    it('should not double-encode special characters in presigned URLs', async () => {
+      delete options.baseUrl;
+      options.presignedUrl = true;
+      const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
+
+      // Test filename with special characters that need URL encoding
+      const specialFilename = 'doc[123].pdf';
+      const fileLocation = await s3.getFileLocation(testConfig, specialFilename);
+
+      // Should be encoded once (not double-encoded)
+      // %5B and %5D are correct encoding for [ and ]
+      // Double encoding would be %255B and %255D
+      expect(fileLocation).toContain('doc%5B123%5D.pdf');
+      expect(fileLocation).not.toContain('doc%255B123%255D.pdf');
+    });
+
+    it('should keep the path separator in presigned URLs for nested filenames', async () => {
+      delete options.baseUrl;
+      options.presignedUrl = true;
+      const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
+
+      // The key is now handed to the SDK unencoded, so the separator has to
+      // survive as a separator rather than becoming %2F.
+      const fileLocation = await s3.getFileLocation(testConfig, 'folder/doc[123].pdf');
+
+      expect(fileLocation).toContain('folder/doc%5B123%5D.pdf');
+      expect(fileLocation).not.toContain('folder%2Fdoc');
+    });
   });
 
   describe('getFileLocation with async baseUrl', () => {


### PR DESCRIPTION
## Issue

Closes: #335

With `presignedUrl: true`, filenames containing URL-sensitive characters were double-encoded, so `doc[123].pdf` was signed as `doc%255B123%255D.pdf` and the link failed.

## Approach

`getFileLocation` pre-encodes the filename for the Parse-served and plain S3 URL forms, then reused that already-encoded value as the S3 object key in the presigned branch. The AWS SDK encodes the key again when it builds the signed URL, hence the double encoding.

The presigned branch now builds its key from the raw filename. That also makes it consistent with every other S3 command in the adapter: `createFile`, `deleteFile`, `getFileData` and `handleFileStream` all pass `this._bucketPrefix + filename` unencoded. Worth stating plainly, because it makes this more than a cosmetic URL bug: the presigned URL was signed against a key that did not match the key `createFile` stored the object under, so it pointed at an object that does not exist.

Non-presigned URLs continue to use the pre-encoded `fileKey` and are unchanged.

Filenames containing `/` are unaffected. The SDK encodes the key per path segment and preserves the separator, so a raw key is correct there too:

| Filename | Presigned URL path |
| --- | --- |
| `doc[123].pdf` | `doc%5B123%5D.pdf` |
| `folder/doc[123].pdf` | `folder/doc%5B123%5D.pdf` |
| `a b+c&d.pdf` | `a%20b%2Bc%26d.pdf` |
| `héllo.pdf` | `h%C3%A9llo.pdf` |

This fix does not depend on any other PR.

## Tasks

- [x] Add tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected presigned file links so special characters are encoded only once.
  * Preserved folder paths in presigned links for files stored in nested locations.
  * Improved access to files with brackets, spaces, ampersands, and other special characters.

* **Tests**
  * Added coverage for special-character filenames and nested file paths.
  * Verified generated links remain valid across supported file naming scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related pull requests

These all touch `createFile` or `getFileLocation` in `index.js`. Merging them in this order leaves the fewest conflicts, verified by trial merges of all six together, which pass the suite once resolved:

**#336 → #594 → #597 → #591 → #593 → #242**

- #336 presigned urls used a pre-encoded key
- #594 bucket region missing from the direct access url
- #597 asynchronous `generateKey`
- #591 percent-encoding of the `Location` url
- #593 `Location` omitted the bucket for custom endpoints
- #242 `createFile` reporting the stored name and url

#336 and #594 conflict with nothing. The rest collide on the `createFile` prologue and on the same anchor in `spec/test.spec.js`, where the conflict truncates each side's block, so the incoming `describe` has to be re-inserted whole rather than resolved line by line.
