### PR TITLE
refactor: Bump @aws-sdk/client-s3, @aws-sdk/lib-storage, @aws-sdk/s3-request-presigner from 3.1021.0 to 3.1023.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "5.3.1",
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/client-s3": "3.1021.0",
-        "@aws-sdk/lib-storage": "3.1021.0",
-        "@aws-sdk/s3-request-presigner": "3.1021.0"
+        "@aws-sdk/client-s3": "3.1023.0",
+        "@aws-sdk/lib-storage": "3.1023.0",
+        "@aws-sdk/s3-request-presigner": "3.1023.0"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1021.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1021.0.tgz",
-      "integrity": "sha512-BCfggq8gYSjlKOZlMSVApix3cgKAQIWGeoJFX/AU5HMvqz1BZBEw83jJFL9LYrqTPCocH8NGl++1Xr70ro+jcg==",
+      "version": "3.1023.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1023.0.tgz",
+      "integrity": "sha512-IvNy49sdoCWd3fgHQxail3y0UQdfKj1Xk0VPu9HTwlog60o9Lmp5ykjZ2LlIuHEPaxq4Siih707GB/ulUWgetw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -814,9 +814,9 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.1021.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1021.0.tgz",
-      "integrity": "sha512-DmbaWPd4HSbz/gLS6tFZ6hTjDw3OvgheOqEywT/Z8sxdaSMIkEJjt2CcYKy7YiqG3DrkvZ/te5oGjgIQOUlhnw==",
+      "version": "3.1023.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1023.0.tgz",
+      "integrity": "sha512-1SFnmHlkKQgQxAt7/nK2f7b90kmymceojIbZT+yoSlHh2rJk2Dcjld8zo6lwUdfROrMwi4PP+z5nRMPG+d7zjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-endpoint": "^4.4.28",
@@ -832,7 +832,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.1021.0"
+        "@aws-sdk/client-s3": "^3.1023.0"
       }
     },
     "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
@@ -1086,9 +1086,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1021.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1021.0.tgz",
-      "integrity": "sha512-kkIzsIAc7wnG7vVRkZFIwJ3noOyF3S6ozOQ9t2KxzPde1LsmpmPwYbmiB91DzdfuGySdk4Hpb0JmHh4KhGECXQ==",
+      "version": "3.1023.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1023.0.tgz",
+      "integrity": "sha512-SGC/9cctIEgDQpqsStntTyGRI8bLL/mqZ4Dh54ggrLnwza20uhpVPPxV6omem0Es3362/7UGDGe0Pa+QQPCiDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/signature-v4-multi-region": "^3.996.15",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/parse-community/parse-server-s3-adapter#readme",
   "dependencies": {
-    "@aws-sdk/client-s3": "3.1021.0",
-    "@aws-sdk/lib-storage": "3.1021.0",
-    "@aws-sdk/s3-request-presigner": "3.1021.0"
+    "@aws-sdk/client-s3": "3.1023.0",
+    "@aws-sdk/lib-storage": "3.1023.0",
+    "@aws-sdk/s3-request-presigner": "3.1023.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",


### PR DESCRIPTION
Closes #507
Closes #508
Closes #509

### Changes

Patch version bump for all three @aws-sdk packages from 3.1021.0 to 3.1023.0.

### Breaking Changes

None

### Code Changes Required

None — drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS SDK v3 S3-related dependencies to the latest patch version, including client-s3, lib-storage, and s3-request-presigner packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->