### PR TITLE
refactor: Bump @aws-sdk/s3-request-presigner from 3.1028.0 to 3.1029.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "3.1028.0",
         "@aws-sdk/lib-storage": "3.1028.0",
-        "@aws-sdk/s3-request-presigner": "3.1028.0"
+        "@aws-sdk/s3-request-presigner": "3.1029.0"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -1086,9 +1086,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1028.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1028.0.tgz",
-      "integrity": "sha512-T46EyIIHUaF/I2zhjtSUO4/87QdhqobClCscJawrxe2h/8nZJoO3DQDVZ4tMDl5UV/B5SPz6+xwki8jGylTF4Q==",
+      "version": "3.1029.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1029.0.tgz",
+      "integrity": "sha512-YbHPaha4DYgJWdPorGV5ZSCCqHafGj4GiyqXmXFlCJSsqlOd3xEcemhOZGjrB9epdiVEUtB3DDJXGYYj55ITdQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/signature-v4-multi-region": "^3.996.16",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.1028.0",
     "@aws-sdk/lib-storage": "3.1028.0",
-    "@aws-sdk/s3-request-presigner": "3.1028.0"
+    "@aws-sdk/s3-request-presigner": "3.1029.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",


### PR DESCRIPTION
Bumps `@aws-sdk/s3-request-presigner` from 3.1028.0 to 3.1029.0.

### Changelog summary
Routine minor release within the AWS SDK v3 monorepo. Includes internal updates aligned with the rest of the AWS SDK v3 packages; no breaking changes for consumers of the presigner API.

### Risk
Low. Minor version bump, production dependency. No API surface changes affecting this adapter.

Closes #534