### PR TITLE
refactor: Bump @aws-sdk/client-s3, @aws-sdk/lib-storage, @aws-sdk/s3-request-presigner to 3.1030.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "5.3.1",
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/client-s3": "3.1028.0",
-        "@aws-sdk/lib-storage": "3.1028.0",
-        "@aws-sdk/s3-request-presigner": "3.1029.0"
+        "@aws-sdk/client-s3": "3.1030.0",
+        "@aws-sdk/lib-storage": "3.1030.0",
+        "@aws-sdk/s3-request-presigner": "3.1030.0"
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
@@ -553,9 +553,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1028.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1028.0.tgz",
-      "integrity": "sha512-KL8PREFJxyWXUjMQR6Krq/OjZ5qbcV1QFjtA7Q7oMW5XaFO9YoSBtBxQeeXO4um6vYSmRVYVDTvEKZDcNbyeXw==",
+      "version": "3.1030.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1030.0.tgz",
+      "integrity": "sha512-sgGb4ub0JXnHaXnok5td7A1KGwENFPwOrwgzvpkeWq9w16Sl7x2KhYtVl+Fdd/7LAvaEtm3HqrYtNmm2d0OXmQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -814,9 +814,9 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.1028.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1028.0.tgz",
-      "integrity": "sha512-AT937nfpMDW/8oDiWPBP/BdGJ6943ALMWTBpUi0fD0qelA3lyZgErSnX7yp9j3t/enzyHdlyBOPq9kGFBt0Xcg==",
+      "version": "3.1030.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1030.0.tgz",
+      "integrity": "sha512-1Hn+m1sioy3OMvF/I1uDz9QjpqcE3QSsHvz0Y0UXyMthNCpvAEvN4qO9RWBDGfVqddY1Flsp0rfvjwYP4KVr+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-endpoint": "^4.4.29",
@@ -832,7 +832,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.1028.0"
+        "@aws-sdk/client-s3": "^3.1030.0"
       }
     },
     "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
@@ -1086,9 +1086,9 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.1029.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1029.0.tgz",
-      "integrity": "sha512-YbHPaha4DYgJWdPorGV5ZSCCqHafGj4GiyqXmXFlCJSsqlOd3xEcemhOZGjrB9epdiVEUtB3DDJXGYYj55ITdQ==",
+      "version": "3.1030.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1030.0.tgz",
+      "integrity": "sha512-rLM1DjBb9QlQwijKGtVSfWGi2gEz8yYj244RRWsPoGAhl57xKS0OGq6MygP/UYTPVc6r5qr4a8Gq1wos4QxnVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/signature-v4-multi-region": "^3.996.16",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/parse-community/parse-server-s3-adapter#readme",
   "dependencies": {
-    "@aws-sdk/client-s3": "3.1028.0",
-    "@aws-sdk/lib-storage": "3.1028.0",
-    "@aws-sdk/s3-request-presigner": "3.1029.0"
+    "@aws-sdk/client-s3": "3.1030.0",
+    "@aws-sdk/lib-storage": "3.1030.0",
+    "@aws-sdk/s3-request-presigner": "3.1030.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",


### PR DESCRIPTION
Closes #536
Closes #537
Closes #538

This PR combines three co-dependent Dependabot PRs that bump AWS SDK packages which share peer dependencies and must be upgraded together:

| Package | From | To |
|---|---|---|
| `@aws-sdk/client-s3` | 3.1028.0 | 3.1030.0 |
| `@aws-sdk/lib-storage` | 3.1028.0 | 3.1030.0 |
| `@aws-sdk/s3-request-presigner` | 3.1029.0 | 3.1030.0 |

These are minor version bumps of production dependencies.