### PR TITLE
refactor: Bump @aws-sdk/lib-storage from 3.1030.0 to 3.1032.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "3.1032.0",
-        "@aws-sdk/lib-storage": "3.1030.0",
+        "@aws-sdk/lib-storage": "3.1032.0",
         "@aws-sdk/s3-request-presigner": "3.1032.0"
       },
       "devDependencies": {
@@ -777,15 +777,15 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.1030.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1030.0.tgz",
-      "integrity": "sha512-1Hn+m1sioy3OMvF/I1uDz9QjpqcE3QSsHvz0Y0UXyMthNCpvAEvN4qO9RWBDGfVqddY1Flsp0rfvjwYP4KVr+w==",
+      "version": "3.1032.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1032.0.tgz",
+      "integrity": "sha512-jXXKbrRWYvLlCCO8suiOiFrkcsO/zVYjdPZpVnDLSO6Nled7VvxwRkjnM1/l5CnOHAW6VGhR3nrU/+LmqeGQYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^4.4.29",
-        "@smithy/protocol-http": "^5.3.13",
-        "@smithy/smithy-client": "^4.12.9",
-        "@smithy/types": "^4.14.0",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
@@ -795,7 +795,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.1030.0"
+        "@aws-sdk/client-s3": "^3.1032.0"
       }
     },
     "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/parse-community/parse-server-s3-adapter#readme",
   "dependencies": {
     "@aws-sdk/client-s3": "3.1032.0",
-    "@aws-sdk/lib-storage": "3.1030.0",
+    "@aws-sdk/lib-storage": "3.1032.0",
     "@aws-sdk/s3-request-presigner": "3.1032.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps `@aws-sdk/lib-storage` from 3.1030.0 to 3.1032.0.

This is a replacement PR for the Dependabot PR #548, created from a fork branch so CI can run. The earlier attempt was deferred because `@aws-sdk/lib-storage@3.1032.0` requires peer `@aws-sdk/client-s3@^3.1032.0`; `@aws-sdk/client-s3` has since been upgraded to 3.1032.0 on `master`, so the peer now resolves cleanly.

### Changes
- `@aws-sdk/lib-storage`: 3.1030.0 -> 3.1032.0 (manifest + lock file only)

### Breaking Changes
None. Patch-level bump within the same 3.x line; peer dependency on `@aws-sdk/client-s3@^3.1032.0` is satisfied by the version already on `master`.

### Code Changes Required
None.

Closes #548