### PR TITLE
refactor: Bump parse-server from 9.8.0 to 9.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "jasmine-spec-reporter": "7.0.0",
         "mongodb-runner": "6.7.3",
         "nyc": "18.0.0",
-        "parse-server": "9.8.0",
+        "parse-server": "9.10.0",
         "rewire": "9.0.1",
         "semantic-release": "25.0.3",
         "semver": "7.7.4"
@@ -3031,29 +3031,6 @@
       },
       "engines": {
         "node": "20 || 22 || 24"
-      }
-    },
-    "node_modules/@parse/node-apn/node_modules/jsonwebtoken": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^4.0.1",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
       }
     },
     "node_modules/@parse/push-adapter": {
@@ -9282,13 +9259,13 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -9302,29 +9279,6 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jwa": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/jws": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^1.4.2",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/jwa": {
@@ -12715,9 +12669,9 @@
       }
     },
     "node_modules/parse-server": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.8.0.tgz",
-      "integrity": "sha512-osUyuA2yqE5gBnmzcCvR3r9cEtZFNVglFufQsRG5pJaOJzb/+x1T5sbhdDvgE8C55hkhAKzLL2xFYPf1NPONWA==",
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/parse-server/-/parse-server-9.10.0.tgz",
+      "integrity": "sha512-f4IIsWLsh30mOJl6u6SB3GBrj7Zj4f69dKkI0PPZxNeVttlKFBEg/VHc2AQrWKWRvnIlWy22o2UdX4ECPDPCIw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -12741,7 +12695,7 @@
         "graphql-relay": "0.10.2",
         "graphql-upload": "15.0.2",
         "intersect": "1.0.1",
-        "jsonwebtoken": "9.0.2",
+        "jsonwebtoken": "9.0.3",
         "jwks-rsa": "3.2.0",
         "ldapjs": "3.0.7",
         "lodash": "4.18.1",
@@ -12750,8 +12704,8 @@
         "mongodb": "7.1.0",
         "mustache": "4.2.0",
         "otpauth": "9.5.0",
-        "parse": "8.5.0",
-        "path-to-regexp": "8.4.0",
+        "parse": "8.6.0",
+        "path-to-regexp": "8.4.2",
         "pg-monitor": "3.1.0",
         "pg-promise": "12.6.0",
         "pluralize": "8.0.0",
@@ -12768,7 +12722,7 @@
         "parse-server": "bin/parse-server"
       },
       "engines": {
-        "node": ">=20.19.0 <21.0.0 || >=22.12.0 <23.0.0 || >=24.11.0 <25.0.0"
+        "node": ">=20.19.0 <21.0.0 || >=22.13.0 <23.0.0 || >=24.11.0 <25.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -12776,6 +12730,47 @@
       },
       "optionalDependencies": {
         "@node-rs/bcrypt": "1.10.7"
+      }
+    },
+    "node_modules/parse-server/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/parse-server/node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/parse-server/node_modules/parse": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/parse/-/parse-8.6.0.tgz",
+      "integrity": "sha512-AZjc8yGo8/iTZFpCXWw/r1qNusiUGWtq9i92/u0jNd+Iupg3EJUSV/OOyTrCeav8NDyo92wVS5O3iKAYPlhlsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "7.29.2",
+        "@babel/runtime-corejs3": "7.29.2",
+        "crypto-js": "4.2.0",
+        "idb-keyval": "6.2.2",
+        "react-native-crypto-js": "1.0.0",
+        "ws": "8.20.0"
+      },
+      "engines": {
+        "node": ">=20.19.0 <21 || >=22.13.0 <23 || >=24.1.0 <25"
       }
     },
     "node_modules/parse-server/node_modules/ws": {
@@ -12886,9 +12881,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jasmine-spec-reporter": "7.0.0",
     "mongodb-runner": "6.7.3",
     "nyc": "18.0.0",
-    "parse-server": "9.8.0",
+    "parse-server": "9.10.0",
     "rewire": "9.0.1",
     "semantic-release": "25.0.3",
     "semver": "7.7.4"


### PR DESCRIPTION
Closes #565
Closes #550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Parse Server dependency to version 9.10.0.
  * Refreshed related dependency versions and lockfile entries for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->