### PR TITLE
refactor: Bump @aws-sdk/lib-storage from 3.1032.0 to 3.1090.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "3.1032.0",
-        "@aws-sdk/lib-storage": "3.1032.0",
+        "@aws-sdk/lib-storage": "3.1090.0",
         "@aws-sdk/s3-request-presigner": "3.1032.0"
       },
       "devDependencies": {
@@ -777,15 +777,13 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.1032.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1032.0.tgz",
-      "integrity": "sha512-jXXKbrRWYvLlCCO8suiOiFrkcsO/zVYjdPZpVnDLSO6Nled7VvxwRkjnM1/l5CnOHAW6VGhR3nrU/+LmqeGQYg==",
+      "version": "3.1090.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1090.0.tgz",
+      "integrity": "sha512-b3KVOQnhHK30J9ZjUwKvB9Ka0ly06HywRQsZzIxSe7MGhKmFpPIGe61WF+OaLPoZmOQ4VOxZeEdgWE0G3HgJxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^4.4.30",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.11",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
         "buffer": "5.6.0",
         "events": "3.3.0",
         "stream-browserify": "3.0.0",
@@ -795,7 +793,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.1032.0"
+        "@aws-sdk/client-s3": "^3.1090.0"
       }
     },
     "node_modules/@aws-sdk/lib-storage/node_modules/buffer": {
@@ -3954,9 +3952,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
-      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "version": "3.29.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.6.tgz",
+      "integrity": "sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/parse-community/parse-server-s3-adapter#readme",
   "dependencies": {
     "@aws-sdk/client-s3": "3.1032.0",
-    "@aws-sdk/lib-storage": "3.1032.0",
+    "@aws-sdk/lib-storage": "3.1090.0",
     "@aws-sdk/s3-request-presigner": "3.1032.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #573

Bumps [@aws-sdk/lib-storage](https://github.com/aws/aws-sdk-js-v3/tree/HEAD/lib/lib-storage) from 3.1032.0 to 3.1090.0.

## Changes
- Production dependency (`dependencies`) bump: `@aws-sdk/lib-storage` `3.1032.0` -> `3.1090.0` (routine minor within AWS SDK JS v3, lockstep monorepo release).
- Lockfile updated accordingly, including the shared transitive `@smithy/core` `3.29.3` -> `3.29.6`. Diff is limited to the `@aws-sdk`/`@smithy` subtree (+10/-12), matching the upstream Dependabot lockfile change.

## Breaking
- None. Every intermediate release (3.1033.0 through 3.1090.0) is a "Version bump only for package @aws-sdk/lib-storage" entry in the changelog — no functional or API changes to `lib-storage`. AWS SDK v3 sub-packages are versioned in lockstep.

## Code Changes
- None required. Manifest and lockfile only; no source changes.

Note: `@aws-sdk/lib-storage@3.1090.0` declares a peer dependency on `@aws-sdk/client-s3@^3.1090.0` while `client-s3` remains pinned at `3.1032.0`. This mirrors the upstream Dependabot PR (which bumps `lib-storage` alone); AWS SDK v3 sub-packages within the same major are compatible in practice, so the peer notice is non-blocking.
