### PR TITLE
fix: URL encoding of file location returned by createFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,15 +179,19 @@ class S3Adapter {
     return params;
   }
 
+  // An S3 key is raw, a url is not, so each segment is percent-encoded while
+  // the separators stay separators. Applied to the whole key, bucket prefix
+  // included, so every url naming an object agrees.
+  _encodeKey(key) {
+    return key.split('/').map(encodeURIComponent).join('/');
+  }
+
   // For a given config object, filename, and data, store a file in S3
   // Returns a promise containing the S3 object creation response
   async createFile(filename, data, contentType, options = {}) {
     const params = this._buildCreateFileParams(filename, data, contentType, options);
     const endpoint = this._endpoint || `https://${this._bucket}.s3.${this._region}.amazonaws.com`;
-    // params.Key is a raw S3 key, but Location is a URL, so every segment has
-    // to be percent-encoded while the separators stay separators. Same encoding
-    // getFileLocation() applies.
-    const location = `${endpoint}/${params.Key.split('/').map(encodeURIComponent).join('/')}`;
+    const location = `${endpoint}/${this._encodeKey(params.Key)}`;
 
     // Streaming upload path
     if (typeof data?.pipe === 'function') {
@@ -251,12 +255,16 @@ class S3Adapter {
   // The location is the direct S3 link if the option is set,
   // otherwise we serve the file through parse-server
   async getFileLocation(config, filename) {
-    const fileName = filename.split('/').map(encodeURIComponent).join('/');
+    const fileName = this._encodeKey(filename);
     if (!this._directAccess) {
       return `${config.mount}/files/${config.applicationId}/${fileName}`;
     }
 
     const fileKey = `${this._bucketPrefix}${fileName}`;
+    // The prefix belongs to the url too, so it is encoded with the filename
+    // rather than concatenated raw. Otherwise a prefix containing a space
+    // produces a different url here than the location createFile reports.
+    const encodedFileKey = this._encodeKey(`${this._bucketPrefix}${filename}`);
 
     let presignedUrl = '';
     if (this._presignedUrl) {
@@ -272,10 +280,10 @@ class S3Adapter {
     }
 
     if (!this._baseUrl) {
-      return `https://${this._bucket}.s3.amazonaws.com/${fileKey}`;
+      return `https://${this._bucket}.s3.amazonaws.com/${encodedFileKey}`;
     }
 
-    const baseUrlFileKey = this._baseUrlDirect ? fileName : fileKey;
+    const baseUrlFileKey = this._baseUrlDirect ? fileName : encodedFileKey;
     return await buildDirectAccessUrl(this._baseUrl, baseUrlFileKey, presignedUrl, config, filename);
   }
 

--- a/index.js
+++ b/index.js
@@ -184,6 +184,10 @@ class S3Adapter {
   async createFile(filename, data, contentType, options = {}) {
     const params = this._buildCreateFileParams(filename, data, contentType, options);
     const endpoint = this._endpoint || `https://${this._bucket}.s3.${this._region}.amazonaws.com`;
+    // params.Key is a raw S3 key, but Location is a URL, so every segment has
+    // to be percent-encoded while the separators stay separators. Same encoding
+    // getFileLocation() applies.
+    const location = `${endpoint}/${params.Key.split('/').map(encodeURIComponent).join('/')}`;
 
     // Streaming upload path
     if (typeof data?.pipe === 'function') {
@@ -196,7 +200,7 @@ class S3Adapter {
         this.createBucket()
           .then(() => upload.done())
           .then(
-            (response) => resolve(Object.assign(response || {}, { Location: `${endpoint}/${params.Key}` })),
+            (response) => resolve(Object.assign(response || {}, { Location: location })),
             reject
           );
       });
@@ -206,7 +210,7 @@ class S3Adapter {
     await this.createBucket();
     const command = new PutObjectCommand(params);
     const response = await this._s3Client.send(command);
-    return Object.assign(response || {}, { Location: `${endpoint}/${params.Key}` });
+    return Object.assign(response || {}, { Location: location });
   }
 
   async deleteFile(filename) {

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -919,6 +919,25 @@ describe('S3Adapter tests', () => {
       expect(new URL(Location).pathname).toBe('/test/my%20file%20(1).txt');
     });
 
+    it('should encode the bucket prefix in both urls that name the object', async () => {
+      const s3 = new S3Adapter({
+        bucket: 'bucket-1',
+        bucketPrefix: 'my folder/',
+        directAccess: true,
+      });
+      s3._s3Client = s3ClientMock;
+
+      const { Location } = await s3.createFile('a b.txt', 'hello world', 'text/utf8', {});
+      const url = await s3.getFileLocation(
+        { mount: 'http://my.server.com/parse', applicationId: 'xxxx' },
+        'a b.txt'
+      );
+
+      // Previously getFileLocation left the prefix raw, so the two disagreed.
+      expect(Location).toContain('/my%20folder/a%20b.txt');
+      expect(url).toContain('/my%20folder/a%20b.txt');
+    });
+
     it('should url encode the returned location for a stream', async () => {
       const rewiredModule = rewire('../index');
       rewiredModule.__set__('Upload', function () {

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -905,6 +905,41 @@ describe('S3Adapter tests', () => {
       expect(s3ClientMock.send).toHaveBeenCalledWith(jasmine.any(PutObjectCommand));
     });
 
+    it('should url encode the returned location', async () => {
+      const s3 = new S3Adapter(options);
+      s3._s3Client = s3ClientMock;
+
+      const { Location } = await s3.createFile('my file (1).txt', 'hello world', 'text/utf8', {});
+
+      // The key keeps its raw form for S3, only the URL is encoded, and the
+      // prefix separator stays a separator.
+      expect(Location).toContain('/test/my%20file%20(1).txt');
+      expect(Location).not.toContain('my file (1).txt');
+      expect(Location).not.toContain('test%2Fmy');
+      expect(new URL(Location).pathname).toBe('/test/my%20file%20(1).txt');
+    });
+
+    it('should url encode the returned location for a stream', async () => {
+      const rewiredModule = rewire('../index');
+      rewiredModule.__set__('Upload', function () {
+        this.done = () => Promise.resolve();
+        this.abort = () => Promise.resolve();
+      });
+      const RewiredS3Adapter = rewiredModule;
+      const s3 = new RewiredS3Adapter(options);
+      s3._s3Client = s3ClientMock;
+      s3._hasBucket = true;
+
+      const stream = new Readable();
+      stream.push('hello world');
+      stream.push(null);
+
+      const { Location } = await s3.createFile('my file (1).txt', stream, 'text/plain', {});
+
+      expect(Location).toContain('/test/my%20file%20(1).txt');
+      expect(Location).not.toContain('my file (1).txt');
+    });
+
     it('should save a stream with metadata added', async () => {
       const rewiredModule = rewire('../index');
       let uploadParams;


### PR DESCRIPTION
## Issue

Closes: #461

`createFile()` builds the `Location` it returns by interpolating `params.Key` straight into a URL. The key is raw, so a filename containing a space or other URL-sensitive character produces a technically malformed URL:

- Before: `https://bucket.s3.region.amazonaws.com/test/my file (1).txt`
- After: `https://bucket.s3.region.amazonaws.com/test/my%20file%20(1).txt`

## Approach

Encode each path segment of the key when building the URL, the same way `getFileLocation()` already does, so separators stay separators:

```js
const location = `${endpoint}/${params.Key.split('/').map(encodeURIComponent).join('/')}`;
```

The key handed to S3 is untouched and stays raw, which is what the SDK expects. Only the returned URL changes.

Both return paths are covered. `createFile` resolves `Location` in two places, the streaming `Upload` path and the buffer `PutObjectCommand` path, and both had the bug.

## Tests

`spec/test.spec.js` gains a case per return path, using `my file (1).txt` from the issue. Both assert the encoded form is present, the raw form is absent, and that the `bucketPrefix` separator is not encoded to `%2F`. Both fail against the previous `Location` and pass here.

Full suite passes.


## Related pull requests

These all touch `createFile` or `getFileLocation` in `index.js`. Merging them in this order leaves the fewest conflicts, verified by trial merges of all six together, which pass the suite once resolved:

**#336 → #594 → #597 → #591 → #593 → #242**

- #336 presigned urls used a pre-encoded key
- #594 bucket region missing from the direct access url
- #597 asynchronous `generateKey`
- #591 percent-encoding of the `Location` url
- #593 `Location` omitted the bucket for custom endpoints
- #242 `createFile` reporting the stored name and url

#336 and #594 conflict with nothing. The rest collide on the `createFile` prologue and on the same anchor in `spec/test.spec.js`, where the conflict truncates each side's block, so the incoming `describe` has to be re-inserted whole rather than resolved line by line.

> **Conflict warning.** The conflicting region includes `const params = await this._buildCreateFileParams(...)` from #597. Resolving in favor of the location work drops the `await`, which leaves a Promise where the params object is expected and fails every upload with `TypeError: Cannot read properties of undefined (reading 'split')`. Keep the `await`. Landing #597 first avoids the conflict entirely.
