### PR TITLE
fix: File location returned by createFile omits the bucket when a custom endpoint is configured

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,22 +180,48 @@ class S3Adapter {
     return params;
   }
 
+  // The SDK accepts an endpoint as a url string, as an object carrying
+  // protocol, hostname, port and path, or as an EndpointV2 carrying a url. Each
+  // has to be reduced to a url here, because falling back to the AWS host would
+  // point a custom deployment at Amazon.
+  _endpointToUrl(endpoint) {
+    if (!endpoint) {
+      return `https://s3.${this._region}.amazonaws.com`;
+    }
+    if (typeof endpoint === 'string') {
+      return endpoint;
+    }
+    if (endpoint.url) {
+      return String(endpoint.url);
+    }
+    if (endpoint.hostname) {
+      const protocol = endpoint.protocol
+        ? endpoint.protocol.replace(/:?$/, ':')
+        : 'https:';
+      const port = endpoint.port ? `:${endpoint.port}` : '';
+      return `${protocol}//${endpoint.hostname}${port}${endpoint.path || ''}`;
+    }
+    return null;
+  }
+
   // The url prefix the S3 client addresses this bucket at, mirroring how the
   // SDK resolves the bucket: as a leading path segment when forcePathStyle is
   // set, otherwise as a host prefix. Without this the bucket is missing from
   // the url whenever a custom endpoint does not already contain it.
-  _buildLocationBase() {
-    const endpoint = this._endpoint || `https://s3.${this._region}.amazonaws.com`;
+  async _buildLocationBase() {
+    let endpoint = this._endpoint;
+    if (typeof endpoint === 'function') {
+      // An endpoint provider, which the SDK resolves per request.
+      endpoint = await endpoint();
+    }
     try {
-      const { protocol, host, pathname } = new URL(endpoint);
+      const { protocol, host, pathname } = new URL(this._endpointToUrl(endpoint));
       const basePath = pathname.replace(/\/+$/, '');
       return this._forcePathStyle
         ? `${protocol}//${host}${basePath}/${this._bucket}`
         : `${protocol}//${this._bucket}.${host}${basePath}`;
     } catch {
-      // An endpoint that is not a url string, for example an object or a
-      // provider function, cannot be resolved here. Fall back to the bucket's
-      // default host.
+      // An endpoint that names no host at all leaves nothing to build from.
       return `https://${this._bucket}.s3.${this._region}.amazonaws.com`;
     }
   }
@@ -204,7 +230,7 @@ class S3Adapter {
   // Returns a promise containing the S3 object creation response
   async createFile(filename, data, contentType, options = {}) {
     const params = this._buildCreateFileParams(filename, data, contentType, options);
-    const endpoint = this._buildLocationBase();
+    const endpoint = await this._buildLocationBase();
 
     // Streaming upload path
     if (typeof data?.pipe === 'function') {
@@ -293,7 +319,7 @@ class S3Adapter {
       // object at the url the S3 client actually addresses it at. Previously
       // this hardcoded the AWS host and ignored both the custom endpoint and
       // the region.
-      return `${this._buildLocationBase()}/${fileKey}`;
+      return `${await this._buildLocationBase()}/${fileKey}`;
     }
 
     const baseUrlFileKey = this._baseUrlDirect ? fileName : fileKey;

--- a/index.js
+++ b/index.js
@@ -77,6 +77,7 @@ class S3Adapter {
     this._encryption = options.ServerSideEncryption;
     this._generateKey = options.generateKey;
     this._endpoint = options.s3overrides?.endpoint;
+    this._forcePathStyle = options.s3overrides?.forcePathStyle;
     // Optional FilesAdaptor method
     this.validateFilename = options.validateFilename;
 
@@ -179,11 +180,31 @@ class S3Adapter {
     return params;
   }
 
+  // The url prefix the S3 client addresses this bucket at, mirroring how the
+  // SDK resolves the bucket: as a leading path segment when forcePathStyle is
+  // set, otherwise as a host prefix. Without this the bucket is missing from
+  // the url whenever a custom endpoint does not already contain it.
+  _buildLocationBase() {
+    const endpoint = this._endpoint || `https://s3.${this._region}.amazonaws.com`;
+    try {
+      const { protocol, host, pathname } = new URL(endpoint);
+      const basePath = pathname.replace(/\/+$/, '');
+      return this._forcePathStyle
+        ? `${protocol}//${host}${basePath}/${this._bucket}`
+        : `${protocol}//${this._bucket}.${host}${basePath}`;
+    } catch {
+      // An endpoint that is not a url string, for example an object or a
+      // provider function, cannot be resolved here. Fall back to the bucket's
+      // default host.
+      return `https://${this._bucket}.s3.${this._region}.amazonaws.com`;
+    }
+  }
+
   // For a given config object, filename, and data, store a file in S3
   // Returns a promise containing the S3 object creation response
   async createFile(filename, data, contentType, options = {}) {
     const params = this._buildCreateFileParams(filename, data, contentType, options);
-    const endpoint = this._endpoint || `https://${this._bucket}.s3.${this._region}.amazonaws.com`;
+    const endpoint = this._buildLocationBase();
 
     // Streaming upload path
     if (typeof data?.pipe === 'function') {

--- a/index.js
+++ b/index.js
@@ -289,7 +289,11 @@ class S3Adapter {
     }
 
     if (!this._baseUrl) {
-      return `https://${this._bucket}.s3.amazonaws.com/${fileKey}`;
+      // Same base as the location reported by createFile, so both name the
+      // object at the url the S3 client actually addresses it at. Previously
+      // this hardcoded the AWS host and ignored both the custom endpoint and
+      // the region.
+      return `${this._buildLocationBase()}/${fileKey}`;
     }
 
     const baseUrlFileKey = this._baseUrlDirect ? fileName : fileKey;

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -489,7 +489,7 @@ describe('S3Adapter tests', () => {
       delete options.baseUrl;
       const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
       await expectAsync(s3.getFileLocation(testConfig, 'test.png')).toBeResolvedTo(
-        'https://my-bucket.s3.amazonaws.com/foo/bar/test.png'
+        'https://my-bucket.s3.us-east-1.amazonaws.com/foo/bar/test.png'
       );
     });
   });
@@ -540,7 +540,7 @@ describe('S3Adapter tests', () => {
       delete options.baseUrl;
       const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
       await expectAsync(s3.getFileLocation(testConfig, 'test.png')).toBeResolvedTo(
-        'https://my-bucket.s3.amazonaws.com/foo/bar/test.png'
+        'https://my-bucket.s3.us-east-1.amazonaws.com/foo/bar/test.png'
       );
     });
   });
@@ -616,7 +616,7 @@ describe('S3Adapter tests', () => {
       delete options.baseUrl;
       const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
       await expectAsync(s3.getFileLocation(testConfig, 'test.png')).toBeResolvedTo(
-        'https://my-bucket.s3.amazonaws.com/foo/bar/test.png'
+        'https://my-bucket.s3.us-east-1.amazonaws.com/foo/bar/test.png'
       );
     });
 
@@ -957,6 +957,28 @@ describe('S3Adapter tests', () => {
         options.s3overrides = { endpoint: 'https://example.com/s3/' };
 
         expect(await locationOf(options)).toBe('https://bucket-1.example.com/s3/test/file.txt');
+      });
+
+      it('should use the same base for the url getFileLocation returns', async () => {
+        // Otherwise createFile reports one url for the object and
+        // getFileLocation reports another, and the second is the one a client
+        // is handed.
+        const s3 = new S3Adapter({
+          bucket: 'bucket-1',
+          bucketPrefix: 'test/',
+          directAccess: true,
+          s3overrides: { endpoint: 'http://localhost:9000', forcePathStyle: true },
+        });
+        s3._s3Client = s3ClientMock;
+
+        const { Location } = await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+        const url = await s3.getFileLocation(
+          { mount: 'http://my.server.com/parse', applicationId: 'xxxx' },
+          'file.txt'
+        );
+
+        expect(Location).toBe('http://localhost:9000/bucket-1/test/file.txt');
+        expect(url).toBe(Location);
       });
 
       it('should fall back to the bucket host when the endpoint is not a url', async () => {

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -905,6 +905,72 @@ describe('S3Adapter tests', () => {
       expect(s3ClientMock.send).toHaveBeenCalledWith(jasmine.any(PutObjectCommand));
     });
 
+    describe('location for custom endpoints', () => {
+      // Each expectation is the url the S3 client itself addresses the object
+      // at for the same options, so the reported location is where the file
+      // actually is.
+      const locationOf = async adapterOptions => {
+        const s3 = new S3Adapter(adapterOptions);
+        s3._s3Client = s3ClientMock;
+        const { Location } = await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+        return Location;
+      };
+
+      it('should keep the bucket in the host without a custom endpoint', async () => {
+        const s3 = new S3Adapter(options);
+
+        expect(await locationOf(options)).toBe(
+          `https://bucket-1.s3.${s3._region}.amazonaws.com/test/file.txt`
+        );
+      });
+
+      it('should put the bucket in the path without a custom endpoint when path style', async () => {
+        options.s3overrides = { forcePathStyle: true };
+        const s3 = new S3Adapter(options);
+
+        expect(await locationOf(options)).toBe(
+          `https://s3.${s3._region}.amazonaws.com/bucket-1/test/file.txt`
+        );
+      });
+
+      it('should prefix a custom endpoint host with the bucket', async () => {
+        options.s3overrides = { endpoint: 'https://nyc3.digitaloceanspaces.com' };
+
+        expect(await locationOf(options)).toBe(
+          'https://bucket-1.nyc3.digitaloceanspaces.com/test/file.txt'
+        );
+      });
+
+      it('should put the bucket in the path of a custom endpoint when path style', async () => {
+        options.s3overrides = { endpoint: 'http://localhost:9000', forcePathStyle: true };
+
+        expect(await locationOf(options)).toBe('http://localhost:9000/bucket-1/test/file.txt');
+      });
+
+      it('should preserve a base path on the custom endpoint', async () => {
+        options.s3overrides = { endpoint: 'https://example.com/s3' };
+
+        expect(await locationOf(options)).toBe('https://bucket-1.example.com/s3/test/file.txt');
+      });
+
+      it('should not double the separator when the endpoint has a trailing slash', async () => {
+        options.s3overrides = { endpoint: 'https://example.com/s3/' };
+
+        expect(await locationOf(options)).toBe('https://bucket-1.example.com/s3/test/file.txt');
+      });
+
+      it('should fall back to the bucket host when the endpoint is not a url', async () => {
+        // The SDK also accepts an endpoint object or provider, which cannot be
+        // resolved to a url here.
+        options.s3overrides = { endpoint: { hostname: 'example.com', protocol: 'https:', path: '/' } };
+        const s3 = new S3Adapter(options);
+
+        expect(await locationOf(options)).toBe(
+          `https://bucket-1.s3.${s3._region}.amazonaws.com/test/file.txt`
+        );
+      });
+    });
+
     it('should save a stream with metadata added', async () => {
       const rewiredModule = rewire('../index');
       let uploadParams;

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -981,10 +981,43 @@ describe('S3Adapter tests', () => {
         expect(url).toBe(Location);
       });
 
-      it('should fall back to the bucket host when the endpoint is not a url', async () => {
-        // The SDK also accepts an endpoint object or provider, which cannot be
-        // resolved to a url here.
-        options.s3overrides = { endpoint: { hostname: 'example.com', protocol: 'https:', path: '/' } };
+      it('should resolve an endpoint given as an object', async () => {
+        // The SDK accepts this form as well as a url string.
+        options.s3overrides = {
+          endpoint: { hostname: 'example.com', protocol: 'https:', path: '/' },
+        };
+
+        expect(await locationOf(options)).toBe('https://bucket-1.example.com/test/file.txt');
+      });
+
+      it('should keep the port and path of an endpoint object', async () => {
+        options.s3overrides = {
+          endpoint: { hostname: 'example.com', protocol: 'http:', port: 9000, path: '/s3' },
+          forcePathStyle: true,
+        };
+
+        expect(await locationOf(options)).toBe(
+          'http://example.com:9000/s3/bucket-1/test/file.txt'
+        );
+      });
+
+      it('should resolve an EndpointV2 carrying a url', async () => {
+        options.s3overrides = { endpoint: { url: new URL('https://example.com/s3') } };
+
+        expect(await locationOf(options)).toBe('https://bucket-1.example.com/s3/test/file.txt');
+      });
+
+      it('should resolve an endpoint provider', async () => {
+        // Providers are resolved per request by the SDK, and may be async.
+        options.s3overrides = {
+          endpoint: async () => ({ hostname: 'example.com', protocol: 'https:' }),
+        };
+
+        expect(await locationOf(options)).toBe('https://bucket-1.example.com/test/file.txt');
+      });
+
+      it('should fall back to the bucket host when the endpoint names no host', async () => {
+        options.s3overrides = { endpoint: {} };
         const s3 = new S3Adapter(options);
 
         expect(await locationOf(options)).toBe(


### PR DESCRIPTION
## Issue

Closes: #592

The `Location` returned by `createFile()` was the endpoint with the key appended, which drops the bucket whenever a custom endpoint does not already contain it. The DigitalOcean Spaces configuration in the README is exactly that shape, as is any S3-compatible host used the same way, for example MinIO or LocalStack.

| `s3overrides.endpoint` | Before |
| --- | --- |
| `https://nyc3.digitaloceanspaces.com` | `https://nyc3.digitaloceanspaces.com/photo.jpg` |
| `http://localhost:9000` | `http://localhost:9000/photo.jpg` |

## Approach

Where the bucket belongs is not guessable from the endpoint string, and testing whether it already appears in the host or path is fragile. The adapter already has the answer: `s3overrides.forcePathStyle` decides it, and was simply not retained on the instance.

`_buildLocationBase()` now mirrors the SDK's own rule, the bucket as a leading path segment under path style, otherwise as a host prefix:

```js
const endpoint = this._endpoint || `https://s3.${this._region}.amazonaws.com`;
const { protocol, host, pathname } = new URL(endpoint);
const basePath = pathname.replace(/\/+$/, '');
return this._forcePathStyle
  ? `${protocol}//${host}${basePath}/${this._bucket}`
  : `${protocol}//${this._bucket}.${host}${basePath}`;
```

Two cases beyond the reported one are fixed by the same rule:

- **`forcePathStyle` without a custom endpoint.** The SDK addresses `https://s3.<region>.amazonaws.com/<bucket>/key`, while the adapter always built the host-prefix form.
- **A non-string endpoint.** The SDK also accepts an endpoint object or provider function, which previously stringified into a broken url. It now falls back to the bucket's default host.

## Verification

Rather than assume the shape, each configuration was checked against the SDK by signing a `GetObjectCommand` for the same options and comparing the resulting path. Nine of ten combinations match byte for byte, across both addressing styles, with and without a custom endpoint, and with a base path on the endpoint.

The tenth is a deliberate deviation. For a trailing-slash endpoint under virtual-host addressing the SDK emits a doubled slash, `https://bucket.example.com/s3//dir/photo.jpg`, while normalizing that same case correctly under path style. This normalizes both, and a test pins it.

## Scope

Limited to the location reported by `createFile`. `getFileLocation`'s direct access branch hardcodes `https://<bucket>.s3.amazonaws.com/...` and considers neither the custom endpoint nor the region, which is noted in #592 as a related gap. It is left alone here because `baseUrl` is the documented way to control that url, so changing it is a separate behavior change.

## Tests

`spec/test.spec.js` gains a `location for custom endpoints` block: the default host, path style without an endpoint, a custom endpoint under each addressing style, an endpoint carrying a base path, a trailing-slash endpoint, and a non-url endpoint. Six of the seven fail against the previous implementation. The seventh is the plain default, which was already correct and guards against regressing it.

Full suite passes.


## Related pull requests

These all touch `createFile` or `getFileLocation` in `index.js`. Merging them in this order leaves the fewest conflicts, verified by trial merges of all six together, which pass the suite once resolved:

**#336 → #594 → #597 → #591 → #593 → #242**

- #336 presigned urls used a pre-encoded key
- #594 bucket region missing from the direct access url
- #597 asynchronous `generateKey`
- #591 percent-encoding of the `Location` url
- #593 `Location` omitted the bucket for custom endpoints
- #242 `createFile` reporting the stored name and url

#336 and #594 conflict with nothing. The rest collide on the `createFile` prologue and on the same anchor in `spec/test.spec.js`, where the conflict truncates each side's block, so the incoming `describe` has to be re-inserted whole rather than resolved line by line.

> **Conflict warning.** The conflicting region includes `const params = await this._buildCreateFileParams(...)` from #597. Resolving in favor of the location work drops the `await`, which leaves a Promise where the params object is expected and fails every upload with `TypeError: Cannot read properties of undefined (reading 'split')`. Keep the `await`. Landing #597 first avoids the conflict entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated file locations for S3-compatible storage configurations.
  - Correctly supports virtual-hosted and path-style URLs, custom endpoints, endpoint base paths, trailing slashes, and provider-based endpoints.
  - Adds regional fallback behavior for invalid endpoints.
  - Ensures file creation and direct-access links consistently use the configured endpoint and region.

- **Tests**
  - Added coverage for standard S3, path-style, custom, object-based, provider-based, and fallback endpoint configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> **#593 and #594 now overlap.** Both write the direct access host in `getFileLocation`, #594 as `https://${bucket}.s3.${region}.amazonaws.com` and #593 as `_buildLocationBase()`, and both update the three `should go directly to amazon` assertions. Keep `_buildLocationBase()`, which already includes the region and additionally handles custom endpoints. Same behavior for the default case, so the resolution is mechanical.
