### PR TITLE
fix: Bucket region is ignored, breaking access to buckets in opt-in regions

### DIFF
--- a/index.js
+++ b/index.js
@@ -268,7 +268,10 @@ class S3Adapter {
     }
 
     if (!this._baseUrl) {
-      return `https://${this._bucket}.s3.amazonaws.com/${fileKey}`;
+      // The region has to be in the host. The global endpoint only reaches
+      // buckets in regions that are enabled by default, so an opt-in region
+      // such as ap-east-1 is unreachable without it.
+      return `https://${this._bucket}.s3.${this._region}.amazonaws.com/${fileKey}`;
     }
 
     const baseUrlFileKey = this._baseUrlDirect ? fileName : fileKey;

--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -57,6 +57,7 @@ const optionsFromArguments = function optionsFromArguments(args) {
 
     if (otherOptions) {
       options.bucketPrefix = otherOptions.bucketPrefix;
+      options.region = otherOptions.region;
       options.credentials = otherOptions.credentials;
       options.directAccess = otherOptions.directAccess;
       options.fileAcl = otherOptions.fileAcl;

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -216,6 +216,24 @@ describe('S3Adapter tests', () => {
       expect(options.bucket).toEqual('bucket');
     });
 
+    it('should accept a region alongside a bucket string', () => {
+      const args = ['bucket', { region: 'ap-east-1' }];
+      const options = optionsFromArguments(args);
+      expect(options.region).toEqual('ap-east-1');
+    });
+
+    it('should accept a region alongside key, secret and bucket', () => {
+      const args = ['key', 'secret', 'bucket', { region: 'ap-east-1' }];
+      const options = optionsFromArguments(args);
+      expect(options.region).toEqual('ap-east-1');
+    });
+
+    it('should still default the region when the options object omits it', () => {
+      const args = ['key', 'secret', 'bucket', { bucketPrefix: 'test/' }];
+      const options = optionsFromArguments(args);
+      expect(options.region).toEqual('us-east-1');
+    });
+
     it('should accept key, secret, bucket, and options object as args', () => {
       const confObj = { bucketPrefix: 'test/' };
       const args = ['key', 'secret', 'bucket', confObj];
@@ -489,7 +507,21 @@ describe('S3Adapter tests', () => {
       delete options.baseUrl;
       const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
       await expectAsync(s3.getFileLocation(testConfig, 'test.png')).toBeResolvedTo(
-        'https://my-bucket.s3.amazonaws.com/foo/bar/test.png'
+        'https://my-bucket.s3.us-east-1.amazonaws.com/foo/bar/test.png'
+      );
+    });
+
+    it('should address an opt-in region directly', async () => {
+      // The global endpoint does not reach buckets in regions that are not
+      // enabled by default, so the region has to be in the host.
+      const s3 = new S3Adapter({
+        bucket: 'my-bucket',
+        region: 'ap-east-1',
+        directAccess: true,
+        bucketPrefix: 'foo/bar/',
+      });
+      await expectAsync(s3.getFileLocation(testConfig, 'test.png')).toBeResolvedTo(
+        'https://my-bucket.s3.ap-east-1.amazonaws.com/foo/bar/test.png'
       );
     });
   });
@@ -540,7 +572,7 @@ describe('S3Adapter tests', () => {
       delete options.baseUrl;
       const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
       await expectAsync(s3.getFileLocation(testConfig, 'test.png')).toBeResolvedTo(
-        'https://my-bucket.s3.amazonaws.com/foo/bar/test.png'
+        'https://my-bucket.s3.us-east-1.amazonaws.com/foo/bar/test.png'
       );
     });
   });
@@ -616,7 +648,7 @@ describe('S3Adapter tests', () => {
       delete options.baseUrl;
       const s3 = new S3Adapter('accessKey', 'secretKey', 'my-bucket', options);
       await expectAsync(s3.getFileLocation(testConfig, 'test.png')).toBeResolvedTo(
-        'https://my-bucket.s3.amazonaws.com/foo/bar/test.png'
+        'https://my-bucket.s3.us-east-1.amazonaws.com/foo/bar/test.png'
       );
     });
 


### PR DESCRIPTION
## Issue

Closes: #139
Closes: #595

A bucket in a region that is not enabled by default, `ap-east-1` in the report, uploads fine but the url handed back is unusable. The configured region was being lost in two independent places, and the issue only closes when both are fixed.

**The direct access url omitted the region.** `getFileLocation` returned `https://<bucket>.s3.amazonaws.com/<key>`. The global endpoint does not reach buckets in opt-in regions, so the url resolves to nothing for exactly the regions in the report.

**The region never arrived in the first place, for two of the three constructor forms.** `optionsFromArguments` copies an explicit list of fields out of the options object for the string and positional forms, and `region` is the only field in the defaults list that is missing from that copy list. It silently fell back to `us-east-1`:

```js
new S3Adapter('key', 'secret', 'bucket', { region: 'ap-east-1' })._region  // us-east-1
new S3Adapter('bucket', { region: 'ap-east-1' })._region                   // us-east-1
new S3Adapter({ bucket: 'bucket', region: 'ap-east-1' })._region           // ap-east-1
```

## Approach

The url now carries the region, and `region` is copied like every other option. All four forms, including the default, resolve correctly after the change.

## Compatibility

Two behavior changes worth stating rather than leaving to be discovered.

**The direct access url changes host** for every deployment using `directAccess` without a `baseUrl`, from `<bucket>.s3.amazonaws.com` to `<bucket>.s3.<region>.amazonaws.com`. Both forms work for regions enabled by default, so this is not a break, but it is visible to anyone pinning that hostname in a CDN origin or a CORS allowlist. Three existing assertions are updated accordingly.

This is better read as removing an inconsistency than as inventing a url shape: the presigned test already expected `my-bucket.s3.us-east-1.amazonaws.com`, because the SDK builds that url itself. The same adapter was returning two different hosts for the same object depending on whether `presignedUrl` was set. They now agree.

**The options fix changes where the S3 client points**, not just a url. Anyone who declared a non-default region through the string or positional form has been running against `us-east-1` without knowing, and will now get the region they asked for. That is the intent, but it is a change for a configuration that was silently wrong. The exposed population should be very small, since writing to the wrong region fails with `PermanentRedirect`, so such a setup is generally already broken.

## Tests

- A direct access url for a bucket in `ap-east-1`, the case from the report.
- The region surviving each constructor form, and still defaulting when the options object omits it.
- Three existing direct access assertions updated to the regional host.

Full suite passes.


## Related pull requests

These all touch `createFile` or `getFileLocation` in `index.js`. Merging them in this order leaves the fewest conflicts, verified by trial merges of all six together, which pass the suite once resolved:

**#336 → #594 → #597 → #591 → #593 → #242**

- #336 presigned urls used a pre-encoded key
- #594 bucket region missing from the direct access url
- #597 asynchronous `generateKey`
- #591 percent-encoding of the `Location` url
- #593 `Location` omitted the bucket for custom endpoints
- #242 `createFile` reporting the stored name and url

#336 and #594 conflict with nothing. The rest collide on the `createFile` prologue and on the same anchor in `spec/test.spec.js`, where the conflict truncates each side's block, so the incoming `describe` has to be re-inserted whole rather than resolved line by line.


> **#593 and #594 now overlap.** Both write the direct access host in `getFileLocation`, #594 as `https://${bucket}.s3.${region}.amazonaws.com` and #593 as `_buildLocationBase()`, and both update the three `should go directly to amazon` assertions. Keep `_buildLocationBase()`, which already includes the region and additionally handles custom endpoints. Same behavior for the default case, so the resolution is mechanical.
