### PR TITLE
feat: Support asynchronous generateKey and validate the generated key

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,14 +214,25 @@ generateKey: async (filename, contentType, options) => {
   // beforeSave(Parse.File) trigger
   const { userId } = options.metadata || {};
   // a lookup, which is why the generator has to be able to be asynchronous
-  const prefix = await folderForUser(userId);
-  return `${prefix}/${userId}/${Date.now()}_${filename}`;
+  const folder = await folderForUser(userId);
+  return `${folder}/${filename}`;
 }
 ```
 
-It must resolve to a non-empty string, and the key including `bucketPrefix` must
-be at most 1024 bytes of UTF-8, which is the S3 limit for an object key. Anything
-else rejects the upload rather than storing the file under an unusable name.
+The key must be a non-empty string, and including `bucketPrefix` it must be at
+most 1024 bytes of UTF-8, which is the S3 limit for an object key. A generator
+that returns anything else rejects the upload instead of storing the file under
+a name that cannot be resolved.
+
+***Note*** `generateKey` applies to writes only. Parse Server records the
+original filename and resolves reads, deletes and urls from it, so an object
+stored under a different key cannot be read back through Parse Server. That is a
+pre-existing limitation of `generateKey`, not of the asynchronous form, and it is
+tracked in
+[#237](https://github.com/parse-community/parse-server-s3-adapter/issues/237).
+Until it is resolved, use `generateKey` only where the stored key is reached by
+something other than Parse Server's file route, for example a CDN configured
+through `baseUrl`.
 **Note:** there are a few ways you can pass arguments:
 
 ```

--- a/README.md
+++ b/README.md
@@ -210,8 +210,12 @@ asynchronous, so a key can be derived from a lookup:
 
 ```javascript
 generateKey: async (filename, contentType, options) => {
-  const folder = await folderForTenant(options.metadata.tenantId);
-  return `${folder}/${Date.now()}_${filename}`;
+  // metadata is whatever was attached to the file, for example in a
+  // beforeSave(Parse.File) trigger
+  const { userId } = options.metadata || {};
+  // a lookup, which is why the generator has to be able to be asynchronous
+  const prefix = await folderForUser(userId);
+  return `${prefix}/${userId}/${Date.now()}_${filename}`;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,20 @@ var api = new ParseServer({
   filesAdapter: s3adapter
 })
 ```
+
+***Note*** `generateKey` receives `(filename, contentType, options)` and may be
+asynchronous, so a key can be derived from a lookup:
+
+```javascript
+generateKey: async (filename, contentType, options) => {
+  const folder = await folderForTenant(options.metadata.tenantId);
+  return `${folder}/${Date.now()}_${filename}`;
+}
+```
+
+It must resolve to a non-empty string, and the key including `bucketPrefix` must
+be at most 1024 bytes of UTF-8, which is the S3 limit for an object key. Anything
+else rejects the upload rather than storing the file under an unusable name.
 **Note:** there are a few ways you can pass arguments:
 
 ```

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const { Upload } = require('@aws-sdk/lib-storage');
 const optionsFromArguments = require('./lib/optionsFromArguments');
 
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+const MAX_S3_KEY_BYTES = 1024;
+
 const awsCredentialsDeprecationNotice = function awsCredentialsDeprecationNotice() {
   // eslint-disable-next-line no-console
   console.warn(
@@ -143,14 +146,33 @@ class S3Adapter {
     }
   }
 
-  _buildCreateFileParams(filename, data, contentType, options = {}) {
+  async _buildCreateFileParams(filename, data, contentType, options = {}) {
     const params = {
       Bucket: this._bucket,
       Key: this._bucketPrefix + filename,
       Body: data,
     };
     if (this._generateKey instanceof Function) {
-      params.Key = this._bucketPrefix + this._generateKey(filename);
+      // Awaited so the generator may be asynchronous, for example when the key
+      // depends on a lookup. A synchronous generator is unaffected. The content
+      // type and options are passed as well, so a key can be derived from more
+      // than the filename.
+      const key = await this._generateKey(filename, contentType, options);
+      if (typeof key !== 'string' || key.trim().length === 0) {
+        // Without this the key silently becomes the prefix plus "undefined",
+        // and the file is stored under a name nothing can resolve.
+        throw new Error('generateKey must return a non-empty string');
+      }
+      const generatedKey = this._bucketPrefix + key;
+      // An S3 key is at most 1024 bytes of UTF-8, counting the bucket prefix.
+      // Checking here reports the offending key, rather than letting S3 reject
+      // the upload with an error that does not say which part was too long.
+      if (Buffer.byteLength(generatedKey, 'utf8') > MAX_S3_KEY_BYTES) {
+        throw new Error(
+          `generateKey must return a key of at most ${MAX_S3_KEY_BYTES} bytes including the bucket prefix`
+        );
+      }
+      params.Key = generatedKey;
     }
     if (this._fileAcl) {
       if (this._fileAcl === 'none') {
@@ -182,7 +204,7 @@ class S3Adapter {
   // For a given config object, filename, and data, store a file in S3
   // Returns a promise containing the S3 object creation response
   async createFile(filename, data, contentType, options = {}) {
-    const params = this._buildCreateFileParams(filename, data, contentType, options);
+    const params = await this._buildCreateFileParams(filename, data, contentType, options);
     const endpoint = this._endpoint || `https://${this._bucket}.s3.${this._region}.amazonaws.com`;
 
     // Streaming upload path

--- a/index.js
+++ b/index.js
@@ -157,19 +157,31 @@ class S3Adapter {
       // depends on a lookup. A synchronous generator is unaffected. The content
       // type and options are passed as well, so a key can be derived from more
       // than the filename.
-      const key = await this._generateKey(filename, contentType, options);
-      if (typeof key !== 'string' || key.trim().length === 0) {
-        // Without this the key silently becomes the prefix plus "undefined",
-        // and the file is stored under a name nothing can resolve.
-        throw new Error('generateKey must return a non-empty string');
+      const generated = await this._generateKey(filename, contentType, options);
+      // A generator returning a number concatenated into a usable key before
+      // this validation existed, so it keeps working. What is rejected is the
+      // set of values that silently produced a broken key, such as undefined
+      // becoming "undefined" or a promise becoming "[object Promise]".
+      const usable =
+        typeof generated === 'string' ||
+        generated instanceof String ||
+        (typeof generated === 'number' && Number.isFinite(generated));
+      const key = usable ? String(generated) : '';
+      if (key.trim().length === 0) {
+        throw new Error(
+          `generateKey must return a non-empty string, received ${
+            usable ? 'a blank string' : typeof generated
+          }`
+        );
       }
       const generatedKey = this._bucketPrefix + key;
       // An S3 key is at most 1024 bytes of UTF-8, counting the bucket prefix.
       // Checking here reports the offending key, rather than letting S3 reject
       // the upload with an error that does not say which part was too long.
-      if (Buffer.byteLength(generatedKey, 'utf8') > MAX_S3_KEY_BYTES) {
+      const keyBytes = Buffer.byteLength(generatedKey, 'utf8');
+      if (keyBytes > MAX_S3_KEY_BYTES) {
         throw new Error(
-          `generateKey must return a key of at most ${MAX_S3_KEY_BYTES} bytes including the bucket prefix`
+          `generateKey must return a key of at most ${MAX_S3_KEY_BYTES} bytes including the bucket prefix, received ${keyBytes} bytes for "${generatedKey}"`
         );
       }
       params.Key = generatedKey;
@@ -204,27 +216,42 @@ class S3Adapter {
   // For a given config object, filename, and data, store a file in S3
   // Returns a promise containing the S3 object creation response
   async createFile(filename, data, contentType, options = {}) {
-    const params = await this._buildCreateFileParams(filename, data, contentType, options);
     const endpoint = this._endpoint || `https://${this._bucket}.s3.${this._region}.amazonaws.com`;
 
     // Streaming upload path
     if (typeof data?.pipe === 'function') {
-      const upload = new Upload({ client: this._s3Client, params });
       return new Promise((resolve, reject) => {
+        let upload;
+        // Attached synchronously, before the key is built, because building it
+        // may await a caller supplied generateKey. A stream erroring in that
+        // window would otherwise emit with no listener attached, which throws
+        // rather than rejecting.
         data.on('error', (err) => {
-          upload.abort().catch(() => {});
+          if (upload) {
+            upload.abort().catch(() => {});
+          }
           reject(err);
         });
-        this.createBucket()
-          .then(() => upload.done())
-          .then(
-            (response) => resolve(Object.assign(response || {}, { Location: `${endpoint}/${params.Key}` })),
-            reject
-          );
+        this._buildCreateFileParams(filename, data, contentType, options)
+          .then(params => {
+            upload = new Upload({ client: this._s3Client, params });
+            return this.createBucket()
+              .then(() => upload.done())
+              .then((response) =>
+                resolve(Object.assign(response || {}, { Location: `${endpoint}/${params.Key}` }))
+              );
+          })
+          .catch(err => {
+            // Nothing consumed the stream, so close it rather than leaving the
+            // caller's request body open.
+            data.destroy();
+            reject(err);
+          });
       });
     }
 
     // Buffer upload path
+    const params = await this._buildCreateFileParams(filename, data, contentType, options);
     await this.createBucket();
     const command = new PutObjectCommand(params);
     const response = await this._s3Client.send(command);

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -956,7 +956,7 @@ describe('S3Adapter tests', () => {
         // Otherwise the key silently becomes "test/undefined".
         await expectAsync(
           s3.createFile('file.txt', 'hello world', 'text/utf8', {})
-        ).toBeRejectedWithError('generateKey must return a non-empty string');
+        ).toBeRejectedWithError(/generateKey must return a non-empty string/);
       });
 
       it('should reject when the generator returns a blank string', async () => {
@@ -966,7 +966,7 @@ describe('S3Adapter tests', () => {
 
         await expectAsync(
           s3.createFile('file.txt', 'hello world', 'text/utf8', {})
-        ).toBeRejectedWithError('generateKey must return a non-empty string');
+        ).toBeRejectedWithError(/generateKey must return a non-empty string/);
       });
 
       it('should accept a key at the S3 length limit', async () => {
@@ -987,9 +987,7 @@ describe('S3Adapter tests', () => {
 
         await expectAsync(
           s3.createFile('file.txt', 'hello world', 'text/utf8', {})
-        ).toBeRejectedWithError(
-          'generateKey must return a key of at most 1024 bytes including the bucket prefix'
-        );
+        ).toBeRejectedWithError(/at most 1024 bytes/);
       });
 
       it('should measure the key limit in bytes rather than characters', async () => {
@@ -1001,6 +999,71 @@ describe('S3Adapter tests', () => {
         await expectAsync(
           s3.createFile('file.txt', 'hello world', 'text/utf8', {})
         ).toBeRejectedWithError(/at most 1024 bytes/);
+      });
+
+      it('should still accept a generator that returns a number', async () => {
+        // Concatenated into a usable key before the result was validated.
+        options.generateKey = () => 20260813;
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+
+        expect(keyUsed()).toBe('test/20260813');
+      });
+
+      it('should use the generated key on the streaming path', async () => {
+        const rewiredModule = rewire('../index');
+        let uploadParams;
+        rewiredModule.__set__('Upload', function (config) {
+          uploadParams = config.params;
+          this.done = () => Promise.resolve();
+          this.abort = () => Promise.resolve();
+        });
+        const RewiredS3Adapter = rewiredModule;
+        options.generateKey = async filename => `async_${filename}`;
+        const s3 = new RewiredS3Adapter(options);
+        s3._s3Client = s3ClientMock;
+        s3._hasBucket = true;
+
+        const stream = new Readable();
+        stream.push('hello world');
+        stream.push(null);
+
+        await s3.createFile('file.txt', stream, 'text/plain', {});
+
+        expect(uploadParams.Key).toBe('test/async_file.txt');
+      });
+
+      it('should reject rather than throw when a stream errors while the key is generated', async () => {
+        let releaseKey;
+        options.generateKey = () => new Promise(resolve => {
+          releaseKey = () => resolve('late.txt');
+        });
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        const stream = new Readable({ read() {} });
+        const promise = s3.createFile('file.txt', stream, 'text/plain', {});
+        // The stream fails before the key resolves. The listener has to be
+        // attached by now, otherwise this throws instead of rejecting.
+        stream.destroy(new Error('client disconnected'));
+
+        await expectAsync(promise).toBeRejectedWithError('client disconnected');
+        releaseKey();
+      });
+
+      it('should close the stream when the generator rejects', async () => {
+        options.generateKey = () => Promise.reject(new Error('lookup failed'));
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        const stream = new Readable({ read() {} });
+
+        await expectAsync(
+          s3.createFile('file.txt', stream, 'text/plain', {})
+        ).toBeRejectedWithError('lookup failed');
+        expect(stream.destroyed).toBe(true);
       });
 
       it('should reject when an asynchronous generator rejects', async () => {

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -905,6 +905,115 @@ describe('S3Adapter tests', () => {
       expect(s3ClientMock.send).toHaveBeenCalledWith(jasmine.any(PutObjectCommand));
     });
 
+    describe('generateKey', () => {
+      const keyUsed = () => {
+        const put = s3ClientMock.send.calls
+          .all()
+          .find(({ args }) => args[0] instanceof PutObjectCommand);
+        return put.args[0].input.Key;
+      };
+
+      it('should use a key from a synchronous generator', async () => {
+        options.generateKey = filename => `sync_${filename}`;
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+
+        expect(keyUsed()).toBe('test/sync_file.txt');
+      });
+
+      it('should use a key from an asynchronous generator', async () => {
+        options.generateKey = async filename => {
+          await Promise.resolve();
+          return `async_${filename}`;
+        };
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+
+        expect(keyUsed()).toBe('test/async_file.txt');
+      });
+
+      it('should pass the content type and options to the generator', async () => {
+        const generateKey = jasmine.createSpy('generateKey').and.returnValue('key.txt');
+        options.generateKey = generateKey;
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+        const createOptions = { metadata: { foo: 'bar' } };
+
+        await s3.createFile('file.txt', 'hello world', 'text/utf8', createOptions);
+
+        expect(generateKey).toHaveBeenCalledWith('file.txt', 'text/utf8', createOptions);
+      });
+
+      it('should reject when the generator does not return a string', async () => {
+        options.generateKey = () => undefined;
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        // Otherwise the key silently becomes "test/undefined".
+        await expectAsync(
+          s3.createFile('file.txt', 'hello world', 'text/utf8', {})
+        ).toBeRejectedWithError('generateKey must return a non-empty string');
+      });
+
+      it('should reject when the generator returns a blank string', async () => {
+        options.generateKey = () => '   ';
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        await expectAsync(
+          s3.createFile('file.txt', 'hello world', 'text/utf8', {})
+        ).toBeRejectedWithError('generateKey must return a non-empty string');
+      });
+
+      it('should accept a key at the S3 length limit', async () => {
+        // 1024 bytes total, including the 'test/' prefix.
+        options.generateKey = () => 'a'.repeat(1024 - 'test/'.length);
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        await s3.createFile('file.txt', 'hello world', 'text/utf8', {});
+
+        expect(Buffer.byteLength(keyUsed(), 'utf8')).toBe(1024);
+      });
+
+      it('should reject a key over the S3 length limit', async () => {
+        options.generateKey = () => 'a'.repeat(1024);
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        await expectAsync(
+          s3.createFile('file.txt', 'hello world', 'text/utf8', {})
+        ).toBeRejectedWithError(
+          'generateKey must return a key of at most 1024 bytes including the bucket prefix'
+        );
+      });
+
+      it('should measure the key limit in bytes rather than characters', async () => {
+        // 600 characters, but 1200 bytes once encoded.
+        options.generateKey = () => 'é'.repeat(600);
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        await expectAsync(
+          s3.createFile('file.txt', 'hello world', 'text/utf8', {})
+        ).toBeRejectedWithError(/at most 1024 bytes/);
+      });
+
+      it('should reject when an asynchronous generator rejects', async () => {
+        options.generateKey = () => Promise.reject(new Error('lookup failed'));
+        const s3 = new S3Adapter(options);
+        s3._s3Client = s3ClientMock;
+
+        await expectAsync(
+          s3.createFile('file.txt', 'hello world', 'text/utf8', {})
+        ).toBeRejectedWithError('lookup failed');
+      });
+    });
+
     it('should save a stream with metadata added', async () => {
       const rewiredModule = rewire('../index');
       let uploadParams;


### PR DESCRIPTION
## Issue

Closes: #596

`generateKey` was called synchronously and its return value used unchecked, so a key could not be derived from anything asynchronous, and a bad return value failed late: `undefined` became the key `<prefix>undefined`, and an over-long key was rejected by S3 with an error that did not say which part was too long.

Separated out of #242, which originally carried this alongside a change to what `createFile` returns. The two are unrelated, and this one stands on its own.

## Approach

- **Awaited.** The generator may be synchronous or asynchronous. A synchronous generator is unaffected, since awaiting a plain value is a no-op.
- **Given more context.** It now receives `(filename, contentType, options)` rather than just the filename, so a key can account for the content type or the upload's metadata and tags. Existing single-argument generators ignore the extra arguments.
- **Validated.** The result must be a non-empty string, and the key including `bucketPrefix` must be at most 1024 bytes of UTF-8, which is the S3 object key limit. The check counts bytes rather than characters, so a 600 character key of multibyte characters is correctly rejected at 1200 bytes.

## Compatibility

Existing synchronous generators returning a sensible key behave exactly as before, which the current tests cover unchanged.

Two cases that used to be accepted now reject, both of which stored a file that could not be resolved afterwards:

- a generator returning a non-string or a blank string, previously stored as `<prefix>undefined` or a whitespace key
- a generator returning a key beyond the S3 limit, previously an opaque failure from S3

Validation applies only to generated keys. Filenames that pass through without a generator are untouched, keeping this change scoped to the feature.

## Tests

`spec/test.spec.js` gains a `generateKey` block: a synchronous generator, an asynchronous one, the arguments handed to the generator, rejection for a non-string and for a blank string, propagation when an async generator rejects, a key exactly at the 1024 byte limit, a key past it, and a multibyte key that is short in characters but over the limit in bytes.

The README documents the async form, the arguments, and the constraints.

Full suite passes.


## Related pull requests

These all touch `createFile` or `getFileLocation` in `index.js`. Merging them in this order leaves the fewest conflicts, verified by trial merges of all six together, which pass the suite once resolved:

**#336 → #594 → #597 → #591 → #593 → #242**

- #336 presigned urls used a pre-encoded key
- #594 bucket region missing from the direct access url
- #597 asynchronous `generateKey`
- #591 percent-encoding of the `Location` url
- #593 `Location` omitted the bucket for custom endpoints
- #242 `createFile` reporting the stored name and url

#336 and #594 conflict with nothing. The rest collide on the `createFile` prologue and on the same anchor in `spec/test.spec.js`, where the conflict truncates each side's block, so the incoming `describe` has to be re-inserted whole rather than resolved line by line.

> **Conflict warning.** The conflicting region includes `const params = await this._buildCreateFileParams(...)` from #597. Resolving in favor of the location work drops the `await`, which leaves a Promise where the params object is expected and fails every upload with `TypeError: Cannot read properties of undefined (reading 'split')`. Keep the `await`. Landing #597 first avoids the conflict entirely.
