### PR TITLE
feat: Allow large uploads via Blob

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const {
 } = require('@aws-sdk/client-s3');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const { Upload } = require('@aws-sdk/lib-storage');
+const { Readable } = require('stream');
 const optionsFromArguments = require('./lib/optionsFromArguments');
 
 const awsCredentialsDeprecationNotice = function awsCredentialsDeprecationNotice() {
@@ -182,6 +183,14 @@ class S3Adapter {
   // For a given config object, filename, and data, store a file in S3
   // Returns a promise containing the S3 object creation response
   async createFile(filename, data, contentType, options = {}) {
+    // A Blob, and anything else exposing a web stream such as a File, is read
+    // through that stream rather than handed over whole. Buffering it would
+    // materialize the entire file in memory, which is the thing that fails for
+    // uploads past the V8 buffer limit. Converting here means the existing
+    // multipart upload path carries it.
+    if (data && typeof data.stream === 'function' && typeof data.pipe !== 'function') {
+      data = Readable.fromWeb(data.stream());
+    }
     const params = this._buildCreateFileParams(filename, data, contentType, options);
     const endpoint = this._endpoint || `https://${this._bucket}.s3.${this._region}.amazonaws.com`;
 

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -905,6 +905,77 @@ describe('S3Adapter tests', () => {
       expect(s3ClientMock.send).toHaveBeenCalledWith(jasmine.any(PutObjectCommand));
     });
 
+    describe('blob uploads', () => {
+      // Rewires Upload so the multipart path can be observed, and returns the
+      // params it was handed.
+      const captureUpload = async (data, adapterOptions) => {
+        const rewiredModule = rewire('../index');
+        let uploadParams;
+        rewiredModule.__set__('Upload', function (config) {
+          uploadParams = config.params;
+          this.done = () => Promise.resolve();
+          this.abort = () => Promise.resolve();
+        });
+        const RewiredS3Adapter = rewiredModule;
+        const s3 = new RewiredS3Adapter(adapterOptions);
+        s3._s3Client = s3ClientMock;
+        s3._hasBucket = true;
+
+        await s3.createFile('file.txt', data, 'text/plain', {});
+        return uploadParams;
+      };
+
+      it('should upload a blob through the multipart path', async () => {
+        // Not through PutObject, which would hold the whole blob in memory.
+        const uploadParams = await captureUpload(new Blob(['hello world']), options);
+
+        expect(uploadParams).toBeDefined();
+        expect(uploadParams.Key).toBe('test/file.txt');
+        expect(s3ClientMock.send).not.toHaveBeenCalledWith(jasmine.any(PutObjectCommand));
+      });
+
+      it('should hand the upload a readable rather than the blob', async () => {
+        const uploadParams = await captureUpload(new Blob(['hello world']), options);
+
+        // The SDK cannot consume a Blob directly in Node.
+        expect(uploadParams.Body instanceof Readable).toBe(true);
+      });
+
+      it('should preserve the blob contents', async () => {
+        const uploadParams = await captureUpload(new Blob(['hello', ' ', 'world']), options);
+
+        const chunks = [];
+        for await (const chunk of uploadParams.Body) {
+          chunks.push(chunk);
+        }
+        expect(Buffer.concat(chunks).toString()).toBe('hello world');
+      });
+
+      it('should read the blob lazily rather than draining it', async () => {
+        const total = 100;
+        let pulled = 0;
+        // Stands in for a blob too large to hold in memory. Converting it must
+        // not read it to the end, otherwise the whole point is lost.
+        const lazy = {
+          stream: () => new ReadableStream({
+            pull(controller) {
+              pulled += 1;
+              if (pulled >= total) {
+                controller.close();
+                return;
+              }
+              controller.enqueue(new TextEncoder().encode('chunk'));
+            },
+          }),
+        };
+
+        const uploadParams = await captureUpload(lazy, options);
+
+        expect(uploadParams.Body instanceof Readable).toBe(true);
+        expect(pulled).toBeLessThan(total);
+      });
+    });
+
     it('should save a stream with metadata added', async () => {
       const rewiredModule = rewire('../index');
       let uploadParams;


### PR DESCRIPTION
## Issue

Closes: #228

A `Blob` handed to `createFile` has no `pipe`, so it misses the streaming path added in #459 and is passed to `PutObjectCommand` whole. That materializes the entire file in memory, which is exactly what fails for uploads past the V8 buffer limit, the case #228 is about.

Picks up #229 by @dalyaidan1, which implemented this against the v2 SDK. @vahidalizad asked there for it to be redone on v3 after #221 landed, and it was never revisited. This is that rewrite, and it is much smaller now, because #459 already added the multipart upload path that the blob only needs routing into.

## Approach

Anything exposing a web stream, a `Blob` or a `File`, is converted to a `Readable` before the params are built, so the existing `Upload` path carries it:

```js
if (data && typeof data.stream === 'function' && typeof data.pipe !== 'function') {
  data = Readable.fromWeb(data.stream());
}
```

Duck typed on `stream()` rather than `instanceof Blob`, so a `File`, a blob from another realm, or a polyfill all work. The `pipe` check keeps a Node `Readable` on its existing path untouched.

The original PR built its own `PassThrough` and piped into it. That is no longer needed: `Upload` accepts a `Readable` directly and handles the multipart chunking, so this adds no plumbing of its own.

## Behavior

- A `Blob` now streams to S3 in parts instead of being buffered, so memory use is bounded by the part size rather than by the file size.
- `Buffer` and string bodies are unchanged and still use `PutObjectCommand`.
- Node `Readable` bodies are unchanged.

## Tests

`spec/test.spec.js` gains a `blob uploads` block: a blob takes the multipart path rather than `PutObjectCommand`, the upload is handed a `Readable` rather than the blob, the contents survive the conversion, and the source is not drained by the conversion itself, which is the property that makes an oversized file possible at all.

All four fail against the current implementation. Full suite passes.
